### PR TITLE
Move version info as parameter of issue tracker url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": "[less(length(basics('identity').userAssignedIdentities),1)]",
                 "options": {
                     "icon": "Error",
-                    "text": "Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?version=${project.version}&pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li>"
+                    "text": "Select one user-assigned managed identity that has a <b>Contributor</b> role in the subscription.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li>"
                 }
             },
             {
@@ -41,7 +41,7 @@
                             "text": "If you encounter problems during deployment of Liberty on Azure, please report them here.",
                             "link": {
                                 "label": "Issue tracker",
-                                "uri": "https://aka.ms/azure-liberty-aks-issues"
+                                "uri": "https://aka.ms/azure-liberty-aks-issues?version=${project.version}"
                             }
                         }
                     },

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -69,14 +69,14 @@ az aks install-cli
 az aks get-credentials -g $clusterRGName -n $clusterName --overwrite-existing >> $logFile
 
 # Install Open Liberty Operator V0.7.1
-version=0.7.1
+OPERATOR_VERSION=0.7.1
 OPERATOR_NAMESPACE=default
 WATCH_NAMESPACE='""'
-kubectl apply -f https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${version}/openliberty-app-crd.yaml
-curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${version}/openliberty-app-cluster-rbac.yaml \
+kubectl apply -f https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${OPERATOR_VERSION}/openliberty-app-crd.yaml
+curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${OPERATOR_VERSION}/openliberty-app-cluster-rbac.yaml \
     | sed -e "s/OPEN_LIBERTY_OPERATOR_NAMESPACE/${OPERATOR_NAMESPACE}/" \
     | kubectl apply -f - >> $logFile
-curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${version}/openliberty-app-operator.yaml \
+curl -L https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/master/deploy/releases/${OPERATOR_VERSION}/openliberty-app-operator.yaml \
     | sed -e "s/OPEN_LIBERTY_WATCH_NAMESPACE/${WATCH_NAMESPACE}/" \
     | kubectl apply -n ${OPERATOR_NAMESPACE} -f - >> $logFile
 wait_deployment_complete open-liberty-operator $OPERATOR_NAMESPACE ${logFile}


### PR DESCRIPTION
## Change summary

- move version info as parameter of issue tracker url
- rename as `OPERATOR_VERSION` to avoid conflict with the property `version` defined in the `pom.xml`

## Testing

Successfully deployed an AKS cluster with an sample app using the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) of the testing offer.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>