### PR TITLE
Add a deployment script to check the permission of the uami

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -124,7 +124,8 @@
         "const_suffix": "[take(replace(parameters('guidValue'), '-', ''), 6)]",
         "name_acrName": "[if(parameters('createACR'), concat('acr', variables('const_suffix')), parameters('acrName'))]",
         "name_clusterName": "[if(parameters('createCluster'), concat('cluster', variables('const_suffix')), parameters('clusterName'))]",
-        "name_deploymentScriptName": "[concat('script', variables('const_suffix'))]"
+        "name_deploymentScriptName": "[concat('script', variables('const_suffix'))]",
+        "name_cpDeploymentScript": "[concat('cpscript', variables('const_suffix'))]"
     },
     "resources": [
         {
@@ -156,11 +157,28 @@
             }
         },
         {
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "${azure.apiVersion.deploymentScript}",
+            "name": "[variables('name_cpDeploymentScript')]",
+            "location": "[parameters('location')]",
+            "kind": "AzureCLI",
+            "identity": "[parameters('identity')]",
+            "properties": {
+                "AzCliVersion": "2.15.0",
+                "primaryScriptUri": "[uri(variables('const_scriptLocation'), concat('check-permission.sh', parameters('_artifactsLocationSasToken')))]",
+                "cleanupPreference": "OnSuccess",
+                "retentionInterval": "P1D"
+            }
+        },
+        {
             "type": "Microsoft.ContainerRegistry/registries",
             "apiVersion": "${azure.apiVersion.acr}",
             "name": "[variables('name_acrName')]",
             "location": "[parameters('location')]",
             "condition": "[parameters('createACR')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deploymentScripts', variables('name_cpDeploymentScript'))]"
+            ],
             "sku": {
                 "name": "Basic"
             },

--- a/src/main/scripts/check-permission.sh
+++ b/src/main/scripts/check-permission.sh
@@ -33,6 +33,6 @@ principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --quer
 # Check if the user assigned managed identity has Contributor or Owner role
 roleLength=$(az role assignment list --assignee ${principalId} | jq '.[] | [select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="Owner")] | length')
 if [ ${roleLength} -lt 1 ]; then
-    echo "The user-assigned managed identity must has Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    echo "The user-assigned managed identity must have Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
     exit 1
 fi

--- a/src/main/scripts/check-permission.sh
+++ b/src/main/scripts/check-permission.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Get the type of managed identity
+uamiType=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "type" -o tsv)
+if [ $? == 1 ]; then
+    echo "The user-assigned managed identity may not exist or has no access to the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi
+
+# Check if the managed identity is a user-assigned managed identity
+if [[ "${uamiType}" != "Microsoft.ManagedIdentity/userAssignedIdentities" ]]; then
+    echo "You must select a user-assigned managed identity instead of other types, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi
+
+# Query principal Id of the user-assigned managed identity
+principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "principalId" -o tsv)
+
+# Check if the user assigned managed identity has Contributor or Owner role
+roleLength=$(az role assignment list --assignee ${principalId} | jq '.[] | [select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="Owner")] | length')
+if [ ${roleLength} -lt 1 ]; then
+    echo "The user-assigned managed identity must has Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #18 

## Change summary

* Add a deployment script to check the required permissions of the uami before deploying Azure resources

## Testing

The following test cases have already been passed before opening the PR:

* The uami has no access to the subscription: Deployment failed fast
* The uami has Reader role in the subscription: Deployment failed fast
* The uami has Contributor role in the subscription: Deployment succeeded

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>