### PR TITLE
Docker image path fallback and validity check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -305,20 +305,20 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified docker image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
+                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
                                 },
                                 "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
                             },
                             {
                                 "name": "appImagePath",
                                 "type": "Microsoft.Common.TextBox",
-                                "label": "Application docker image path",
+                                "label": "Application container image path",
                                 "placeholder": "Example: docker.io/openliberty/open-liberty:full-java11-openj9-ubi",
-                                "toolTip": "Specify the docker image path of your application.",
+                                "toolTip": "Specify the container image path of your application.",
                                 "constraints": {
                                     "required": true,
                                     "regex": "^(?:(?=[^:\/]{4,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)?((?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*)(?::(?![.-])[a-zA-Z0-9_.-]{1,128})?$",
-                                    "validationMessage": "The value must be a valid docker image path. For example, docker.io/openliberty/open-liberty:full-java11-openj9-ubi"
+                                    "validationMessage": "The value must be a valid container image path. For example, docker.io/openliberty/open-liberty:full-java11-openj9-ubi"
                                 },
                                 "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
                             }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -301,6 +301,15 @@
                                 "visible": "[bool(${samples.available})]"
                             },
                             {
+                                "name": "imagePathInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "If you input a fully qualified docker image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
+                                },
+                                "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
+                            },
+                            {
                                 "name": "appImagePath",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Application docker image path",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -305,7 +305,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "If you input a fully qualified docker image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
+                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified docker image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
                                 },
                                 "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
                             },
@@ -313,6 +313,7 @@
                                 "name": "appImagePath",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Application docker image path",
+                                "placeholder": "Example: docker.io/openliberty/open-liberty:full-java11-openj9-ubi",
                                 "toolTip": "Specify the docker image path of your application.",
                                 "constraints": {
                                     "required": true,

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -114,7 +114,8 @@
     "variables": {
         "const_appImage": "[concat(variables('const_appImageName'), ':', variables('const_appImageTag'))]",
         "const_appImageName": "[concat('image', variables('const_suffix'))]",
-        "const_appImagePath": "[if(empty(parameters('appImagePath')), 'NA', if(equals(length(split(parameters('appImagePath'), '/')), 1), concat('docker.io/library/', parameters('appImagePath')), parameters('appImagePath')))]",
+        "const_appImagePath": "[if(empty(parameters('appImagePath')), 'NA', if(equals(variables('const_appImagePathLen'), 1), concat('docker.io/library/', parameters('appImagePath')), if(equals(variables('const_appImagePathLen'), 2), concat('docker.io/', parameters('appImagePath')), parameters('appImagePath'))))]",
+        "const_appImagePathLen": "[length(split(parameters('appImagePath'), '/'))]",
         "const_appImageTag": "1.0.0",
         "const_appName": "[concat('app', variables('const_suffix'))]",
         "const_appProjName": "[concat('project', variables('const_suffix'))]",

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -114,10 +114,11 @@
     "variables": {
         "const_appImage": "[concat(variables('const_appImageName'), ':', variables('const_appImageTag'))]",
         "const_appImageName": "[concat('image', variables('const_suffix'))]",
+        "const_appImagePath": "[if(empty(parameters('appImagePath')), 'NA', if(equals(length(split(parameters('appImagePath'), '/')), 1), concat('docker.io/library/', parameters('appImagePath')), parameters('appImagePath')))]",
         "const_appImageTag": "1.0.0",
         "const_appName": "[concat('app', variables('const_suffix'))]",
         "const_appProjName": "[concat('project', variables('const_suffix'))]",
-        "const_arguments": "[concat(variables('const_clusterRGName'), ' ', variables('name_clusterName'), ' ', variables('name_acrName'), ' ', parameters('deployApplication'), ' ', if(empty(parameters('appImagePath')), 'NA', parameters('appImagePath')), ' ', variables('const_appName'), ' ', variables('const_appProjName'), ' ', variables('const_appImage'), ' ', parameters('appReplicas'))]",
+        "const_arguments": "[concat(variables('const_clusterRGName'), ' ', variables('name_clusterName'), ' ', variables('name_acrName'), ' ', parameters('deployApplication'), ' ', variables('const_appImagePath'), ' ', variables('const_appName'), ' ', variables('const_appProjName'), ' ', variables('const_appImage'), ' ', parameters('appReplicas'))]",
         "const_clusterRGName": "[if(parameters('createCluster'), resourceGroup().name, parameters('clusterRGName'))]",
         "const_cmdToGetAcrLoginServer": "[concat('az acr show -n ', variables('name_acrName'), ' --query loginServer -o tsv')]",
         "const_scriptLocation": "[uri(parameters('_artifactsLocation'), 'scripts/')]",


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #13
* Resolve #21 

## Change summary

* Fallback to `docker.io` as the registry login server if the user-input docker image path doesn't include the login server
* Add image path example as placeholder text
* Request a public image in the info box
* Check if the source image is valid and exit with the appropriate error message if not
* Remove unnecessary error messages from the list when the deployment failed

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed the application with the user specified docker image path: `websphere-liberty`
* Successfully deployed the application with the user specified docker image path: `ibmcom/websphere-liberty`
* Successfully deployed the application with the user specified docker image path: `docker.io/ibmcom/websphere-liberty`
* Failed to deploy the application with the user specified docker image path: `ibmcom/websphere-liberty-1`

Screenshot for the enhanced **Configure application** blade:
![image](https://user-images.githubusercontent.com/10357495/145151925-e40597e5-d811-4c09-a0fc-e3e80141980b.png)

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>