### PR TITLE
Deploy app to the `default` namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -118,7 +118,7 @@
         "const_appImagePathLen": "[length(split(parameters('appImagePath'), '/'))]",
         "const_appImageTag": "1.0.0",
         "const_appName": "[concat('app', variables('const_suffix'))]",
-        "const_appProjName": "[concat('project', variables('const_suffix'))]",
+        "const_appProjName": "default",
         "const_arguments": "[concat(variables('const_clusterRGName'), ' ', variables('name_clusterName'), ' ', variables('name_acrName'), ' ', parameters('deployApplication'), ' ', variables('const_appImagePath'), ' ', variables('const_appName'), ' ', variables('const_appProjName'), ' ', variables('const_appImage'), ' ', parameters('appReplicas'))]",
         "const_clusterRGName": "[if(parameters('createCluster'), resourceGroup().name, parameters('clusterRGName'))]",
         "const_cmdToGetAcrLoginServer": "[concat('az acr show -n ', variables('name_acrName'), ' --query loginServer -o tsv')]",

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -141,8 +141,11 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-# Create project namespace
-kubectl create namespace ${Project_Name} >> $logFile
+# Create project namespace if it doesn't exist before
+kubectl get namespace ${Project_Name}
+if [[ $? -ne 0 ]]; then
+  kubectl create namespace ${Project_Name} >> $logFile
+fi
 
 # Retrieve login server and credentials of the ACR
 LOGIN_SERVER=$(az acr show -n $acrName --query 'loginServer' -o tsv)


### PR DESCRIPTION
Deploy the app to the `default` namespace instead of creating a new one for the simplicity.
The PR is to resolve #25 .

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>