### PR TITLE
Attach acr to remove the image pull secret

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": "[not(equals(length(basics('identity').userAssignedIdentities), 1))]",
                 "options": {
                     "icon": "Error",
-                    "text": "Select <b>only one</b> user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and a <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
+                    "text": "<b>The deployment will fail unless the roles specified here are assigned to the user-assigned managed identity.</b><br><br>Select <b>only one</b> user-assigned managed identity that has (1) an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription, and (2) a <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
                 }
             },
             {
@@ -18,7 +18,7 @@
                 "type": "Microsoft.ManagedIdentity.IdentitySelector",
                 "label": "Managed Identity Configuration",
                 "toolTip": {
-                    "userAssignedIdentity": "Add a user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and a <b>Directory readers</b> role in Azure AD to enable the application deployment."
+                    "userAssignedIdentity": "Add a user-assigned managed identity that has (1) an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription, and (2) a <b>Directory readers</b> role in Azure AD to enable the application deployment."
                 },
                 "defaultValue": {
                     "systemAssignedIdentity": "Off"

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": "[not(equals(length(basics('identity').userAssignedIdentities), 1))]",
                 "options": {
                     "icon": "Error",
-                    "text": "Select <b>only one</b> user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and an <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
+                    "text": "Select <b>only one</b> user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and a <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
                 }
             },
             {
@@ -18,7 +18,7 @@
                 "type": "Microsoft.ManagedIdentity.IdentitySelector",
                 "label": "Managed Identity Configuration",
                 "toolTip": {
-                    "userAssignedIdentity": "Add a user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and an <b>Directory readers</b> role in Azure AD to enable the application deployment."
+                    "userAssignedIdentity": "Add a user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and a <b>Directory readers</b> role in Azure AD to enable the application deployment."
                 },
                 "defaultValue": {
                     "systemAssignedIdentity": "Off"

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": "[not(equals(length(basics('identity').userAssignedIdentities), 1))]",
                 "options": {
                     "icon": "Error",
-                    "text": "Select <b>only one</b> user-assigned managed identity that has a <b>Contributor</b> role in the subscription.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li>"
+                    "text": "Select <b>only one</b> user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and an <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
                 }
             },
             {
@@ -18,7 +18,7 @@
                 "type": "Microsoft.ManagedIdentity.IdentitySelector",
                 "label": "Managed Identity Configuration",
                 "toolTip": {
-                    "userAssignedIdentity": "Add a user-assigned managed identity that has a <b>Contributor</b> role in the subscription to enable the application deployment."
+                    "userAssignedIdentity": "Add a user-assigned managed identity that has an <b>Owner</b> role or <b>Contributor</b> and <b>User Access Administrator</b> roles in the subscription and an <b>Directory readers</b> role in Azure AD to enable the application deployment."
                 },
                 "defaultValue": {
                     "systemAssignedIdentity": "Off"

--- a/src/main/scripts/check-permission.sh
+++ b/src/main/scripts/check-permission.sh
@@ -30,9 +30,20 @@ fi
 # Query principal Id of the user-assigned managed identity
 principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "principalId" -o tsv)
 
-# Check if the user assigned managed identity has Contributor or Owner role
-roleLength=$(az role assignment list --assignee ${principalId} | jq '.[] | [select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="Owner")] | length')
-if [ ${roleLength} -lt 1 ]; then
-    echo "The user-assigned managed identity must have Contributor or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+# Check if the user assigned managed identity has Owner role or Contributor and User Access Administrator roles
+roleAssignments=$(az role assignment list --assignee ${principalId})
+roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Owner") ] | length')
+if [ ${roleLength} -ne 1 ]; then
+    roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="User Access Administrator") ] | length')
+    if [ ${roleLength} -ne 2 ]; then
+        echo "The user-assigned managed identity must have Contributor and User Access Administrator roles or Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+        exit 1
+    fi
+fi
+
+# Check if the user assigned managed identity has Directory readers role in the Azure AD
+az ad user list 1>/dev/null
+if [ $? == 1 ]; then
+    echo "The user-assigned managed identity must have Directory readers role in the Azure AD, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
     exit 1
 fi

--- a/src/main/scripts/open-liberty-application.yaml.template
+++ b/src/main/scripts/open-liberty-application.yaml.template
@@ -21,7 +21,6 @@ spec:
   replicas: ${Application_Replicas}
   applicationImage: ${Application_Image}
   pullPolicy: Always
-  pullSecret: ${Pull_Secret}
   service:
     type: LoadBalancer
     port: 9080


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #29 

## Change summary

* Modify the `createUiDefinition.json` to notify user that more permissions required to be granted to the uami
* Add the relative permission check in the fail-fast script
* Attach the acr in the `DeploymentScript`
* No longer create the image pull secret and remove it from the app deployment yaml file

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed the offer with the uami granted with **Owner** role in the subscription and **Directory readers** role in Azure AD
* Successfully deployed the offer with the uami granted with **Contributor** and **User Access Administrator** roles in the subscription and **Directory readers** role in Azure AD
* Failed to deploy the offer with the uami without **Directory readers** role granted in Azure AD
* Failed to deploy the offer with the uami without **Owner** role or **Contributor** and **User Access Administrator** roles granted in the subscription

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>