### PR TITLE
Enable/disable availability zones in AKS cluster per region's support of availability zones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.19</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -120,8 +120,13 @@
         "const_appName": "[concat('app', variables('const_suffix'))]",
         "const_appProjName": "default",
         "const_arguments": "[concat(variables('const_clusterRGName'), ' ', variables('name_clusterName'), ' ', variables('name_acrName'), ' ', parameters('deployApplication'), ' ', variables('const_appImagePath'), ' ', variables('const_appName'), ' ', variables('const_appProjName'), ' ', variables('const_appImage'), ' ', parameters('appReplicas'))]",
+        "const_availabilityZones": ["1", "2", "3"],
         "const_clusterRGName": "[if(parameters('createCluster'), resourceGroup().name, parameters('clusterRGName'))]",
         "const_cmdToGetAcrLoginServer": "[concat('az acr show -n ', variables('name_acrName'), ' --query loginServer -o tsv')]",
+        "const_regionsSupportAvailabilityZones": [
+            "australiaeast", "brazilsouth", "canadacentral", "centralindia", "centralus", "eastasia", "eastus", "eastus2", "francecentral", "germanywestcentral", "japaneast",
+            "koreacentral", "northeurope", "norwayeast", "southeastasia", "southcentralus", "swedencentral", "uksouth", "usgovvirginia", "westeurope", "westus2", "westus3"
+        ],
         "const_scriptLocation": "[uri(parameters('_artifactsLocation'), 'scripts/')]",
         "const_suffix": "[take(replace(parameters('guidValue'), '-', ''), 6)]",
         "name_acrName": "[if(parameters('createACR'), concat('acr', variables('const_suffix')), parameters('acrName'))]",
@@ -213,11 +218,7 @@
                         "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
-                        "availabilityZones": [
-                            "1",
-                            "2",
-                            "3"
-                        ]
+                        "availabilityZones": "[if(contains(variables('const_regionsSupportAvailabilityZones'), parameters('location')), variables('const_availabilityZones'), null())]"
                     }
                 ],
                 "networkProfile": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -226,6 +226,7 @@
                     "networkPlugin": "kubenet"
                 }
             },
+            "comments": "Availability zones are only enabled for regions that support them.  Constant const_regionsSupportAvailabilityZones encodes regions that support availability zones. This constant must be kept up to date with https://docs.microsoft.com/en-us/azure/availability-zones/az-overview#azure-regions-with-availability-zones",
             "identity": {
                 "type": "SystemAssigned"
             }


### PR DESCRIPTION
The PR is to fix #35 with the following changes:
- Enable availability zones in AKS cluster if user selected region supports availability zones
- Disable availability zones in AKS cluster if user selected region doesn't support availability zones

Reference: [Create an Azure Kubernetes Service (AKS) cluster that uses availability zones](https://docs.microsoft.com/en-us/azure/aks/availability-zones)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>