### PR TITLE
Add Open Liberty sample image option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,5 @@
         <customer.usage.attribution.id>pid-68a0b448-a573-4012-ab25-d5dc9842063e-partnercenter</customer.usage.attribution.id>
         <aks.start>628cae16-c133-5a2e-ae93-2b44748012fe</aks.start>
         <aks.end>59f5f6da-0a6d-587d-b23c-177108cd8bbf</aks.end>
-        <samples.available>false</samples.available>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -288,17 +288,12 @@
                                             "value": "1"
                                         },
                                         {
-                                            "label": "An Open Liberty sample application image: docker.io/openliberty/open-liberty-sample:1.0.0",
+                                            "label": "The Open Liberty sample image: icr.io/appcafe/open-liberty/samples/getting-started",
                                             "value": "2"
-                                        },
-                                        {
-                                            "label": "A WebSphere Liberty sample application image: docker.io/ibmcom/websphere-liberty-sample:1.0.0",
-                                            "value": "3"
                                         }
                                     ],
                                     "required": true
-                                },
-                                "visible": "[bool(${samples.available})]"
+                                }
                             },
                             {
                                 "name": "imagePathInfo",
@@ -307,7 +302,7 @@
                                     "icon": "Info",
                                     "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
                                 },
-                                "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
+                                "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             },
                             {
                                 "name": "appImagePath",
@@ -320,7 +315,7 @@
                                     "regex": "^(?:(?=[^:\/]{4,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)?((?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*)(?::(?![.-])[a-zA-Z0-9_.-]{1,128})?$",
                                     "validationMessage": "The value must be a valid container image path. For example, docker.io/openliberty/open-liberty:full-java11-openj9-ubi"
                                 },
-                                "visible": "[or(not(bool(${samples.available})), equals(steps('Application').appImageInfo.appImageOption, '1'))]"
+                                "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             }
                         ],
                         "visible": "[bool(steps('Application').deployApplication)]"
@@ -361,7 +356,7 @@
             "createACR": "[bool(steps('Cluster').acrInfo.createACR)]",
             "acrName": "[last(split(steps('Cluster').acrInfo.acrSelector.id, '/'))]",
             "deployApplication": "[bool(steps('Application').deployApplication)]",
-            "appImagePath": "[if(equals(steps('Application').appImageInfo.appImageOption, '2'), 'docker.io/openliberty/open-liberty-sample:1.0.0', if(equals(steps('Application').appImageInfo.appImageOption, '3'), 'docker.io/ibmcom/websphere-liberty-sample:1.0.0', steps('Application').appImageInfo.appImagePath))]",
+            "appImagePath": "[if(equals(steps('Application').appImageInfo.appImageOption, '2'), 'icr.io/appcafe/open-liberty/samples/getting-started', if(equals(steps('Application').appImageInfo.appImageOption, '3'), 'docker.io/ibmcom/websphere-liberty-sample:1.0.0', steps('Application').appImageInfo.appImagePath))]",
             "appReplicas": "[int(steps('Application').appLoadBalancingInfo.appReplicas)]"
         }
     }


### PR DESCRIPTION
The PR is to fix #34 by adding a new option of deploying the Open Liberty sample image in the UI:
* Deploy user own application image:
  ![image](https://user-images.githubusercontent.com/10357495/154625364-d9fa39e5-c1a9-4f52-9288-e8ee7589db2d.png)
* Deploy the Open Liberty sample image:
  ![image](https://user-images.githubusercontent.com/10357495/154625016-92bd5e4c-5c9d-4f8a-a279-65ca79aa61d9.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>