### PR TITLE
Remove '-n default' from the outputs of the deployment

### DIFF
--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -312,22 +312,22 @@
         },
         "cmdToGetAppInstance": {
             "condition": "[parameters('deployApplication')]",
-            "value": "[concat('kubectl get openlibertyapplication ', variables('const_appName'), ' -n ', variables('const_appProjName'))]",
+            "value": "[concat('kubectl get openlibertyapplication ', variables('const_appName'))]",
             "type": "string"
         },
         "cmdToGetAppDeployment": {
             "condition": "[parameters('deployApplication')]",
-            "value": "[concat('kubectl get deployment ', variables('const_appName'), ' -n ', variables('const_appProjName'))]",
+            "value": "[concat('kubectl get deployment ', variables('const_appName'))]",
             "type": "string"
         },
         "cmdToGetAppPods": {
             "condition": "[parameters('deployApplication')]",
-            "value": "[concat('kubectl get pod -n ', variables('const_appProjName'))]",
+            "value": "kubectl get pod",
             "type": "string"
         },
         "cmdToGetAppService": {
             "condition": "[parameters('deployApplication')]",
-            "value": "[concat('kubectl get service ', variables('const_appName'), ' -n ', variables('const_appProjName'))]",
+            "value": "[concat('kubectl get service ', variables('const_appName'))]",
             "type": "string"
         },
         "cmdToLoginInRegistry": {
@@ -358,7 +358,7 @@
             "type": "string"
         },
         "cmdToUpdateOrCreateApplication (Please execute command in `cmdToConnectToCluster` before executing this one)": {
-            "value": "[concat('kubectl apply -f <application-yaml-file-path> -n ', variables('const_appProjName'))]",
+            "value": "kubectl apply -f <application-yaml-file-path>",
             "type": "string"
         }
     }


### PR DESCRIPTION
Since now the app is deployed to `default` namespace, so `-n default` is no longer needed for `kubectl` related commands dumped to the outputs of the deployment.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>