### PR TITLE
Add an info box to help user provide a workable vNet and subnet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.22</version>
+    <version>1.0.23</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -317,7 +317,7 @@
                                         },
                                         "constraints": {
                                             "minAddressPrefixSize": "/24",
-                                            "minAddressCount": 38,
+                                            "minAddressCount": 250,
                                             "requireContiguousAddresses": false
                                         }
                                     }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -288,6 +288,15 @@
                                 }
                             },
                             {
+                                "name": "vnetInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
+                                }
+                            },
+                            {
                                 "name": "vnetForApplicationGateway",
                                 "type": "Microsoft.Network.VirtualNetworkCombo",
                                 "label": {


### PR DESCRIPTION
As the minimum vnet and subnet size are specified, and the subnet needs to be dedicated for the Application gateway, an info box is added to help user provide a workable vNet and subnet.

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>