### PR TITLE
Fix arm-ttk test failure: Parameters property must exist in the template

### DIFF
--- a/src/main/bicep/modules/_pids/_empty.bicep
+++ b/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name


### PR DESCRIPTION
Refer to oracle/weblogic-azure/issues/171, I downloaded the arm-ttk version that partner center is using (https://aka.ms/arm-ttk-azureapps) and ran tests in my local, found the following failure:

```
NestedTemplate pid-68a0b448-a573-4012-ab25-d5dc9842063e-partnercenter [
 Lines 474 - 1316 ]
    [-] Parameters Property Must Exist (344 ms)
        Parameters property must exist in the template

   NestedTemplate 628cae16-c133-5a2e-ae93-2b44748012fe [ Lines 498 - 1340 ]
    [-] Parameters Property Must Exist (344 ms)
        Parameters property must exist in the template

   NestedTemplate 43c417c4-4f5a-555e-a9ba-b2d01d88de1f [ Lines 695 - 1537 ]
    [-] Parameters Property Must Exist (344 ms)
        Parameters property must exist in the template

   NestedTemplate dfa75d32-05de-5635-9833-b004cabcd378 [ Lines 1811 - 2653 ]
    [-] Parameters Property Must Exist (344 ms)
        Parameters property must exist in the template

   NestedTemplate 59f5f6da-0a6d-587d-b23c-177108cd8bbf [ Lines 1838 - 2680 ]
    [-] Parameters Property Must Exist (344 ms)
        Parameters property must exist in the template
```

After applying the changes of the PR (leveraged from [here ](https://github.com/oracle/weblogic-azure/blob/main/weblogic-azure-aks/src/main/bicep/modules/_pids/_empty.bicep#L12-L15)), the failures are fixed.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>