### PR TITLE
Fix issue: Deployment 'vnet-application-gateway' could not be found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.25</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/bicep/modules/_azure-resoruces/_vnetAppGateway.bicep
+++ b/src/main/bicep/modules/_azure-resoruces/_vnetAppGateway.bicep
@@ -44,18 +44,6 @@ var name_nsg = format('olaks-nsg{0}', const_nameSuffix)
 var name_subnet = vnetForApplicationGateway.subnets.gatewaySubnet.name
 var name_vnet = vnetForApplicationGateway.name
 
-// Get existing VNET.
-resource existingVnet 'Microsoft.Network/virtualNetworks@2021-08-01' existing = if (!const_newVnet) {
-  name: name_vnet
-  scope: resourceGroup(vnetForApplicationGateway.resourceGroup)
-}
-
-// Get existing subnet.
-resource existingSubnet 'Microsoft.Network/virtualNetworks/subnets@2021-08-01' existing = if (!const_newVnet) {
-  name: name_subnet
-  parent: existingVnet
-}
-
 // Create new network security group.
 resource nsg 'Microsoft.Network/networkSecurityGroups@2021-08-01' = if (const_newVnet) {
   name: name_nsg
@@ -115,12 +103,8 @@ resource newVnet 'Microsoft.Network/virtualNetworks@2021-08-01' = if (const_newV
       }
     ]
   }
-  dependsOn: [
-    nsg
-  ]
 }
 
-output subIdForApplicationGateway string = const_newVnet ? resourceId('Microsoft.Network/virtualNetworks/subnets', name_vnet, name_subnet) : existingSubnet.id
 // To mitigate ARM-TTK error: Control Named vnetForApplicationGateway must output the resourceGroup property when hideExisting is false
 output vnetResourceGroupName string = vnetRGNameForApplicationGateway
 // To mitigate ARM-TTK error: Control Named vnetForApplicationGateway must output the newOrExisting property when hideExisting is false


### PR DESCRIPTION
The root cause of #54 is that ARM will always seek for deployment `vnetForAppgatewayDeployment` due to the fact that `vnetForAppgatewayDeployment.outputs.subIdForApplicationGateway` refers to deployment `vnetForAppgatewayDeployment` even though it's not deployed because of `enableAppGWIngress` is `false`. 

The PR is to fix #54 with the following changes:
* Move existing VNet and subnet out of  `_vnetAppGateway.bicep` so `subIdForApplicationGateway` is removed from its outputs
* Reference to sub net id directly in `mainTemplate.bicep` using variable `ref_subId `

Tested and verified the issue is fixed with the code changes in the PR:
* Successfully deployed the offer without AGIC enabled
* Successfully deployed the offer with AGIC enabled

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for live testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>