### PR TITLE
Remove uami from user inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Prerequisites
 
 1. You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/free).
-1. You need to create a user-assigned managed identity that has (1) an **Owner** role in the subscription, and (2) a **Directory readers** role in Azure AD.
+1. You need to have an **Owner** role in the subscription.
 1. Install a Java SE implementation (for example, [AdoptOpenJDK OpenJDK 8 LTS/OpenJ9](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=openj9)).
 1. Install [Maven](https://maven.apache.org/download.cgi) 3.5.0 or higher.
 1. Install [Docker](https://docs.docker.com/get-docker/) for your OS.
@@ -34,13 +34,13 @@
       subID=$(az account show --query 'id' -o tsv)
       spBase64Encoded=$(az ad sp create-for-rbac --role Contributor --scopes /subscriptions/${subID} --sdk-auth | base64 -w0)
 
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=true -DcreateACR=true -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=true -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DservicePrincipal=${spBase64Encoded} -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=true -DcreateACR=true -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=true -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DservicePrincipal=${spBase64Encoded} -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       ```
 
    1. Or use an existing AKS cluster and an existing ACR instance without AGIC:
 
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DidentityId=<user-assigned-managed-identity-id> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       ```
 
 1. Change to `./target/cli` directory

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
    1. Or use an existing AKS cluster and an existing ACR instance without AGIC:
 
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DacrRGName=<acr-group-name> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       ```
 
 1. Change to `./target/cli` directory

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Prerequisites
 
 1. You will need an Azure subscription. If you don't have one, you can get one for free for one year [here](https://azure.microsoft.com/free).
-1. You need to have an **Owner** role in the subscription.
+1. You need to have either an **Owner** role or **Contributor** and **User Access Administrator** roles in the subscription.
 1. Install a Java SE implementation (for example, [AdoptOpenJDK OpenJDK 8 LTS/OpenJ9](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=openj9)).
 1. Install [Maven](https://maven.apache.org/download.cgi) 3.5.0 or higher.
 1. Install [Docker](https://docs.docker.com/get-docker/) for your OS.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.25</version>
+    <version>1.0.26</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -618,6 +618,7 @@
             "clusterRGName": "[last(take(split(steps('Cluster').clusterInfo.clusterSelector.id, '/'), 5))]",
             "createACR": "[bool(steps('Cluster').acrInfo.createACR)]",
             "acrName": "[last(split(steps('Cluster').acrInfo.acrSelector.id, '/'))]",
+            "acrRGName": "[last(take(split(steps('Cluster').acrInfo.acrSelector.id, '/'), 5))]",
             "enableAppGWIngress": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
             "vnetForApplicationGateway": "[steps('section_appGateway').appgwIngress.vnetForApplicationGateway]",
             "newOrExistingVnetForApplicationGateway": "[steps('section_appGateway').appgwIngress.vnetForApplicationGateway.newOrExisting]",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -5,27 +5,12 @@
     "parameters": {
         "basics": [
             {
-                "name": "errInfo",
+                "name": "infoForBeforeDeployment",
                 "type": "Microsoft.Common.InfoBox",
-                "visible": "[not(equals(length(basics('identity').userAssignedIdentities), 1))]",
+                "visible": true,
                 "options": {
-                    "icon": "Error",
-                    "text": "<b>The deployment will fail unless the roles specified here are assigned to the user-assigned managed identity.</b><br><br>Select <b>only one</b> user-assigned managed identity that has (1) an <b>Owner</b> role in the subscription, and (2) a <b>Directory readers</b> role in Azure AD.<br><br>You can find more details from the following articles:<li><a href='https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity' target='_blank'>Create a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity#user-assigned-managed-identity' target='_blank'>Assign a role to a user-assigned managed identity</a></li><li><a href='https://docs.microsoft.com/azure/active-directory/roles/manage-roles-portal#assign-a-role' target='_blank'>Assign Azure AD roles to a user-assigned managed identity</a></li>"
-                }
-            },
-            {
-                "name": "identity",
-                "type": "Microsoft.ManagedIdentity.IdentitySelector",
-                "label": "Managed Identity Configuration",
-                "toolTip": {
-                    "userAssignedIdentity": "Add a user-assigned managed identity that has (1) an <b>Owner</b> role in the subscription, and (2) a <b>Directory readers</b> role in Azure AD to enable the application deployment."
-                },
-                "defaultValue": {
-                    "systemAssignedIdentity": "Off"
-                },
-                "options": {
-                    "hideSystemAssignedIdentity": true,
-                    "hideUserAssignedIdentity": false
+                    "icon": "Info",
+                    "text": "The Azure identity deploying this offer must have <a href='https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#owner'>Owner</a> role of the current subscription.</li>"
                 }
             },
             {
@@ -625,7 +610,6 @@
         ],
         "outputs": {
             "location": "[location()]",
-            "identity": "[basics('identity')]",
             "createCluster": "[bool(steps('Cluster').clusterInfo.createCluster)]",
             "vmSize": "[steps('Cluster').clusterInfo.vmSizeSelect]",
             "minCount": "[int(steps('Cluster').clusterInfo.minCount)]",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -10,7 +10,7 @@
                 "visible": true,
                 "options": {
                     "icon": "Info",
-                    "text": "The Azure identity deploying this offer must have <a href='https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#owner'>Owner</a> role of the current subscription.</li>"
+                    "text": "The Azure identity deploying this offer must have one of the following two sets of Azure role-based access control roles:<br> <li><a href='https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor'>Contributor</a> <b>and</b> <a href='https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#user-access-administrator'>User Access Administrator</a> of the current subscription.</li><li><a href='https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#owner'>Owner</a> of the current subscription.</li>"
                 }
             },
             {

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -5,14 +5,6 @@
         "_artifactsLocation": {
             "value": "${artifactsLocationBase}/src/main/"
         },
-        "identity": {
-            "value": {
-                "type": "userAssigned",
-                "userAssignedIdentities": {
-                    "${identityId}": {}
-                }
-            }
-        },
         "createCluster": {
             "value": "${createCluster}"
         },

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -20,6 +20,9 @@
         "acrName": {
             "value": "${acrName}"
         },
+        "acrRGName": {
+            "value": "${acrRGName}"
+        },
         "enableAppGWIngress": {
             "value": "${enableAppGWIngress}"
         },

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -441,6 +441,7 @@ module primaryDsDeployment 'modules/_deployment-scripts/_ds-primary.bicep' = {
     _artifactsLocationSasToken: _artifactsLocationSasToken
     identity: obj_uamiForDeploymentScript
     arguments: const_arguments
+    deployApplication: deployApplication
     enableAppGWIngress: enableAppGWIngress
     appFrontendTlsSecretName: const_appFrontendTlsSecretName
     enableCookieBasedAffinity: enableCookieBasedAffinity

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -24,9 +24,6 @@ param _artifactsLocationSasToken string = ''
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
-@description('User-assigned managed identity granted with contributor role of the same subscription')
-param identity object
-
 @description('Flag indicating whether to create a new cluster or not')
 param createCluster bool = true
 
@@ -177,7 +174,6 @@ var const_regionsSupportAvailabilityZones = [
   'westus2'
   'westus3'
 ]
-var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
 var name_acrName = createACR ? format('acr{0}', guidValue) : acrName
 var name_appGatewayPublicIPAddressName = format('{0}{1}', appGatewayPublicIPAddressName, guidValue)
 var name_clusterName = createCluster ? format('cluster{0}', guidValue) : clusterName
@@ -188,6 +184,13 @@ var name_primaryDsName = format('primaryds{0}', guidValue)
 var name_subnet = vnetForApplicationGateway.subnets.gatewaySubnet.name
 var name_vnet = vnetForApplicationGateway.name
 var ref_subId = const_newVnet ? resourceId('Microsoft.Network/virtualNetworks/subnets', name_vnet, name_subnet) : existingSubnet.id
+
+var obj_uamiForDeploymentScript = {
+  type: 'UserAssigned'
+  userAssignedIdentities: {
+    '${uamiDeployment.outputs.uamiIdForDeploymentScript}': {}
+  }
+}
 
 // Workaround arm-ttk test "Parameter Types Should Be Consistent"
 var _appgwUsePrivateIP = appgwUsePrivateIP
@@ -200,64 +203,40 @@ module partnerCenterPid './modules/_pids/_empty.bicep' = {
   params: {}
 }
 
+module uamiDeployment 'modules/_uamiAndRoles.bicep' = {
+  name: 'uami-deployment'
+  params: {
+    location: location
+  }
+}
+
 module aksStartPid './modules/_pids/_empty.bicep' = {
   name: '628cae16-c133-5a2e-ae93-2b44748012fe'
   params: {}
 }
 
-resource preflightDsDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+module preflightDsDeployment 'modules/_deployment-scripts/_ds-preflight.bicep' = {
   name: name_prefilghtDsName
-  location: location
-  kind: 'AzureCLI'
-  identity: identity
-  properties: {
-    azCliVersion: '2.15.0'
-    primaryScriptUri: uri(const_scriptLocation, format('preflight.sh{0}', _artifactsLocationSasToken))
-    environmentVariables: [
-      {
-        name: 'ENABLE_APPLICATION_GATEWAY_INGRESS_CONTROLLER'
-        value: string(enableAppGWIngress)
-      }
-      {
-        name: 'VNET_FOR_APPLICATIONGATEWAY'
-        value: string(vnetForApplicationGateway)
-      }
-      {
-        name: 'APPLICATION_GATEWAY_CERTIFICATE_OPTION'
-        value: appGatewayCertificateOption
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_NAME'
-        value: keyVaultName
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_RESOURCEGROUP'
-        value: keyVaultResourceGroup
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_FRONTEND_CERT_DATA_SECRET_NAME'
-        value: keyVaultSSLCertDataSecretName
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_FRONTEND_CERT_PASSWORD_SECRET_NAME'
-        value: keyVaultSSLCertPasswordSecretName
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_FRONTEND_CERT_DATA'
-        secureValue: appGatewaySSLCertData
-      }
-      {
-        name: 'APPLICATION_GATEWAY_SSL_FRONTEND_CERT_PASSWORD'
-        secureValue: appGatewaySSLCertPassword
-      }
-      {
-        name: 'BASE64_FOR_SERVICE_PRINCIPAL'
-        secureValue: servicePrincipal
-      }
-    ]
-    cleanupPreference: 'OnSuccess'
-    retentionInterval: 'P1D'
+  params: {
+    name: name_prefilghtDsName
+    location: location
+    _artifactsLocation: _artifactsLocation
+    _artifactsLocationSasToken: _artifactsLocationSasToken
+    identity: obj_uamiForDeploymentScript
+    enableAppGWIngress: enableAppGWIngress
+    vnetForApplicationGateway: vnetForApplicationGateway
+    appGatewayCertificateOption: appGatewayCertificateOption
+    keyVaultName: keyVaultName
+    keyVaultResourceGroup: keyVaultResourceGroup
+    keyVaultSSLCertDataSecretName: keyVaultSSLCertDataSecretName
+    keyVaultSSLCertPasswordSecretName: keyVaultSSLCertPasswordSecretName
+    appGatewaySSLCertData: appGatewaySSLCertData
+    appGatewaySSLCertPassword: appGatewaySSLCertPassword
+    servicePrincipal: servicePrincipal
   }
+  dependsOn: [
+    uamiDeployment
+  ]
 }
 
 resource acrDeployment 'Microsoft.ContainerRegistry/registries@2021-09-01' = if (createACR) {
@@ -349,7 +328,7 @@ module appgwSecretDeployment 'modules/_azure-resoruces/_keyvaultForGateway.bicep
   params: {
     certificateDataValue: appGatewaySSLCertData
     certificatePasswordValue: appGatewaySSLCertPassword
-    identity: identity
+    identity: obj_uamiForDeploymentScript
     location: location
     sku: keyVaultSku
     subjectName: format('CN={0}', const_azureSubjectName)
@@ -372,7 +351,7 @@ module queryPrivateIPFromSubnet 'modules/_deployment-scripts/_ds_query_available
   params: {
     _artifactsLocation: _artifactsLocation
     _artifactsLocationSasToken: _artifactsLocationSasToken
-    identity: identity
+    identity: obj_uamiForDeploymentScript
     location: location
     subnetId: ref_subId
 
@@ -407,7 +386,7 @@ module networkingDeployment 'modules/_deployment-scripts/_ds-create-agic.bicep' 
     _artifactsLocationSasToken: _artifactsLocationSasToken
     location: location
 
-    identity: identity
+    identity: obj_uamiForDeploymentScript
 
     appgwCertificateOption: appGatewayCertificateOption
     appgwFrontendSSLCertData: existingKeyvault.getSecret((!enableAppGWIngress || appGatewayCertificateOption == const_appGatewaySSLCertOptionHaveKeyVault) ? keyVaultSSLCertDataSecretName : appgwSecretDeployment.outputs.sslCertDataSecretName)
@@ -437,35 +416,18 @@ module appgwEndPid './modules/_pids/_empty.bicep' = if (enableAppGWIngress) {
   ]
 }
 
-resource primaryDsDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+module primaryDsDeployment 'modules/_deployment-scripts/_ds-primary.bicep' = {
   name: name_primaryDsName
-  location: location
-  kind: 'AzureCLI'
-  identity: identity
-  properties: {
-    azCliVersion: '2.15.0'
+  params: {
+    name: name_primaryDsName
+    location: location
+    _artifactsLocation: _artifactsLocation
+    _artifactsLocationSasToken: _artifactsLocationSasToken
+    identity: obj_uamiForDeploymentScript
     arguments: const_arguments
-    primaryScriptUri: uri(const_scriptLocation, format('install.sh{0}', _artifactsLocationSasToken))
-    supportingScriptUris: [
-      uri(const_scriptLocation, format('open-liberty-application.yaml.template{0}', _artifactsLocationSasToken))
-      uri(const_scriptLocation, format('open-liberty-application-agic.yaml.template{0}', _artifactsLocationSasToken))
-    ]
-    environmentVariables: [
-      {
-        name: 'ENABLE_APP_GW_INGRESS'
-        value: string(enableAppGWIngress)
-      }
-      {
-        name: 'APP_FRONTEND_TLS_SECRET_NAME'
-        value: string(const_appFrontendTlsSecretName)
-      }
-      {
-        name: 'ENABLE_COOKIE_BASED_AFFINITY'
-        value: string(enableCookieBasedAffinity)
-      }
-    ]
-    cleanupPreference: 'OnSuccess'
-    retentionInterval: 'P1D'
+    enableAppGWIngress: enableAppGWIngress
+    appFrontendTlsSecretName: const_appFrontendTlsSecretName
+    enableCookieBasedAffinity: enableCookieBasedAffinity
   }
   dependsOn: [
     clusterDeployment
@@ -481,7 +443,7 @@ module aksEndPid './modules/_pids/_empty.bicep' = {
   ]
 }
 
-output appHttpEndpoint string = deployApplication ? (enableAppGWIngress ? appgwDeployment.outputs.appGatewayURL : primaryDsDeployment.properties.outputs.appEndpoint ) : ''
+output appHttpEndpoint string = deployApplication ? (enableAppGWIngress ? appgwDeployment.outputs.appGatewayURL : primaryDsDeployment.outputs.appEndpoint ) : ''
 output appHttpsEndoint string = deployApplication && enableAppGWIngress ? appgwDeployment.outputs.appGatewaySecuredURL : ''
 output clusterName string = name_clusterName
 output clusterRGName string = const_clusterRGName
@@ -499,6 +461,6 @@ output cmdToLoginInRegistry string = format('az acr login -n {0}', name_acrName)
 output cmdToPullImageFromRegistry string = deployApplication ? format('docker pull $({0})/{1}', const_cmdToGetAcrLoginServer, const_appImage) : ''
 output cmdToTagImageWithRegistry string = format('docker tag <source-image-path> $({0})/<target-image-name:tag>', const_cmdToGetAcrLoginServer)
 output cmdToPushImageToRegistry string = format('docker push $({0})/<target-image-name:tag>', const_cmdToGetAcrLoginServer)
-output appDeploymentYaml string = deployApplication? format('echo "{0}" | base64 -d', primaryDsDeployment.properties.outputs.appDeploymentYaml) : ''
-output appDeploymentTemplateYaml string =  !deployApplication ? format('echo "{0}" | base64 -d', primaryDsDeployment.properties.outputs.appDeploymentYaml) : ''
+output appDeploymentYaml string = deployApplication? format('echo "{0}" | base64 -d', primaryDsDeployment.outputs.appDeploymentYaml) : ''
+output appDeploymentTemplateYaml string =  !deployApplication ? format('echo "{0}" | base64 -d', primaryDsDeployment.outputs.appDeploymentYaml) : ''
 output cmdToUpdateOrCreateApplication string = 'kubectl apply -f <application-yaml-file-path>'

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -320,7 +320,7 @@ resource clusterDeployment 'Microsoft.ContainerService/managedClusters@2021-02-0
 }
 
 module acrPullRoleAssignment 'modules/_rolesAssignment/_acrPullRoleAssignment.bicep' = {
-  name: 'allow-agic-access-current-resource-group'
+  name: 'assign-acrpull-role-to-kubelet-identity'
   scope: resourceGroup(const_acrRGName)
   params: {
     aksClusterName: name_clusterName

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -325,6 +325,8 @@ module acrPullRoleAssignment 'modules/_rolesAssignment/_acrPullRoleAssignment.bi
   params: {
     aksClusterName: name_clusterName
     aksClusterRGName: const_clusterRGName
+    acrName: name_acrName
+    acrRGName: const_acrRGName
   }
   dependsOn: [
     clusterDeployment

--- a/src/main/bicep/modules/_azure-resoruces/_keyvault/_keyvaultWithNewCert.bicep
+++ b/src/main/bicep/modules/_azure-resoruces/_keyvault/_keyvaultWithNewCert.bicep
@@ -15,7 +15,7 @@
 */
 
 @description('Managed identity to be used for the deployment script. Currently, only user-assigned MSI is supported.')
-param identity object
+param identity object = {}
 
 @description('Used to name the new Azure Key Vault resoure.')
 param keyVaultName string = 'kv-${uniqueString(utcValue)}'

--- a/src/main/bicep/modules/_azure-resoruces/_keyvaultForGateway.bicep
+++ b/src/main/bicep/modules/_azure-resoruces/_keyvaultForGateway.bicep
@@ -25,7 +25,7 @@ param certificatePasswordValue string = newGuid()
 @description('Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.')
 param enabledForTemplateDeployment bool = true
 
-param identity object
+param identity object = {}
 param location string
 param permission object = {
   certificates: [

--- a/src/main/bicep/modules/_deployment-scripts/_ds-create-agic.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-create-agic.bicep
@@ -19,7 +19,7 @@ param _artifactsLocation string = deployment().properties.templateLink.uri
 param _artifactsLocationSasToken string = ''
 param location string
 
-param identity object
+param identity object = {}
 
 @allowed([
   'haveCert'

--- a/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
@@ -1,0 +1,97 @@
+/*
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param _artifactsLocation string = deployment().properties.templateLink.uri
+@secure()
+param _artifactsLocationSasToken string = ''
+param location string
+param name string = ''
+param identity object = {}
+param enableAppGWIngress bool = false
+param vnetForApplicationGateway object = {}
+param appGatewayCertificateOption string = ''
+param keyVaultName string = ''
+param keyVaultResourceGroup string = ''
+param keyVaultSSLCertDataSecretName string = ''
+param keyVaultSSLCertPasswordSecretName string = ''
+@secure()
+param appGatewaySSLCertData string = ''
+@secure()
+param appGatewaySSLCertPassword string = ''
+@secure()
+param servicePrincipal string = ''
+
+param utcValue string = utcNow()
+
+var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
+var const_primaryScript = 'preflight.sh'
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: name
+  location: location
+  kind: 'AzureCLI'
+  identity: identity
+  properties: {
+    azCliVersion: '2.15.0'
+    environmentVariables: [
+      {
+        name: 'ENABLE_APPLICATION_GATEWAY_INGRESS_CONTROLLER'
+        value: string(enableAppGWIngress)
+      }
+      {
+        name: 'VNET_FOR_APPLICATIONGATEWAY'
+        value: string(vnetForApplicationGateway)
+      }
+      {
+        name: 'APPLICATION_GATEWAY_CERTIFICATE_OPTION'
+        value: appGatewayCertificateOption
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_NAME'
+        value: keyVaultName
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_RESOURCEGROUP'
+        value: keyVaultResourceGroup
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_FRONTEND_CERT_DATA_SECRET_NAME'
+        value: keyVaultSSLCertDataSecretName
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_KEYVAULT_FRONTEND_CERT_PASSWORD_SECRET_NAME'
+        value: keyVaultSSLCertPasswordSecretName
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_FRONTEND_CERT_DATA'
+        secureValue: appGatewaySSLCertData
+      }
+      {
+        name: 'APPLICATION_GATEWAY_SSL_FRONTEND_CERT_PASSWORD'
+        secureValue: appGatewaySSLCertPassword
+      }
+      {
+        name: 'BASE64_FOR_SERVICE_PRINCIPAL'
+        secureValue: servicePrincipal
+      }
+    ]
+    primaryScriptUri: uri(const_scriptLocation, '${const_primaryScript}${_artifactsLocationSasToken}')
+
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    forceUpdateTag: utcValue
+  }
+}

--- a/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
@@ -21,6 +21,7 @@ param location string
 param name string = ''
 param identity object = {}
 param arguments string = ''
+param deployApplication bool = false
 param enableAppGWIngress bool = false
 param appFrontendTlsSecretName string =''
 param enableCookieBasedAffinity bool = false
@@ -65,5 +66,5 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   }
 }
 
-output appEndpoint string = deploymentScript.properties.outputs.appEndpoint
+output appEndpoint string = (deployApplication && !enableAppGWIngress) ? deploymentScript.properties.outputs.appEndpoint : ''
 output appDeploymentYaml string = deploymentScript.properties.outputs.appDeploymentYaml

--- a/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
@@ -1,0 +1,69 @@
+/*
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param _artifactsLocation string = deployment().properties.templateLink.uri
+@secure()
+param _artifactsLocationSasToken string = ''
+param location string
+param name string = ''
+param identity object = {}
+param arguments string = ''
+param enableAppGWIngress bool = false
+param appFrontendTlsSecretName string =''
+param enableCookieBasedAffinity bool = false
+
+param utcValue string = utcNow()
+
+var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
+var const_olaTemplate='open-liberty-application.yaml.template'
+var const_olaAgicTemplate='open-liberty-application-agic.yaml.template'
+var const_primaryScript = 'install.sh'
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: name
+  location: location
+  kind: 'AzureCLI'
+  identity: identity
+  properties: {
+    azCliVersion: '2.15.0'
+    environmentVariables: [
+      {
+        name: 'ENABLE_APP_GW_INGRESS'
+        value: string(enableAppGWIngress)
+      }
+      {
+        name: 'APP_FRONTEND_TLS_SECRET_NAME'
+        value: string(appFrontendTlsSecretName)
+      }
+      {
+        name: 'ENABLE_COOKIE_BASED_AFFINITY'
+        value: string(enableCookieBasedAffinity)
+      }
+    ]
+    arguments: arguments
+    primaryScriptUri: uri(const_scriptLocation, '${const_primaryScript}${_artifactsLocationSasToken}')
+    supportingScriptUris: [
+      uri(const_scriptLocation, format('{0}{1}', const_olaTemplate, _artifactsLocationSasToken))
+      uri(const_scriptLocation, format('{0}{1}', const_olaAgicTemplate, _artifactsLocationSasToken))
+    ]
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    forceUpdateTag: utcValue
+  }
+}
+
+output appEndpoint string = deploymentScript.properties.outputs.appEndpoint
+output appDeploymentYaml string = deploymentScript.properties.outputs.appDeploymentYaml

--- a/src/main/bicep/modules/_deployment-scripts/_ds_query_available_private_ip_from_subnet.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds_query_available_private_ip_from_subnet.bicep
@@ -21,7 +21,7 @@ param _artifactsLocationSasToken string = ''
 param subnetId string = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/resourcegroupname/providers/Microsoft.Network/virtualNetworks/vnetname/subnets/subnetname'
 param knownIP string = '10.0.0.1'
 
-param identity object
+param identity object = {}
 param location string
 param utcValue string = utcNow()
 

--- a/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
@@ -14,8 +14,8 @@
  limitations under the License.
 */
 
-param aksClusterName string 
-param aksClusterRGName string
+param aksClusterName string = ''
+param aksClusterRGName string = ''
 param utcValue string = utcNow()
 
 var const_APIVersion = '2020-12-01'

--- a/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
@@ -1,0 +1,42 @@
+/*
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param aksClusterName string 
+param aksClusterRGName string
+param utcValue string = utcNow()
+
+var const_APIVersion = '2020-12-01'
+var name_kubeletIdentityAcrPullRoleAssignmentName = guid('${resourceGroup().id}${utcValue}ForKubeletIdentity')
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+var const_roleDefinitionIdOfAcrPull = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-02-01' existing = {
+  name: aksClusterName
+  scope: resourceGroup(aksClusterRGName)
+}
+
+resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+  name: name_kubeletIdentityAcrPullRoleAssignmentName
+  properties: {
+    description: 'Assign Resource Group Contributor role to User Assigned Managed Identity '
+    principalId: reference(aksCluster.id, const_APIVersion , 'Full').properties.identityProfile.kubeletidentity.objectId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', const_roleDefinitionIdOfAcrPull)
+  }
+  dependsOn: [
+    aksCluster
+  ]
+}

--- a/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
@@ -1,0 +1,52 @@
+/*
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+Description: assign roles cross resource group.
+Usage:
+  module roleAssignment '_roleAssignmentinSubscription.bicep' = {
+    name: 'assign-role'
+    scope: subscription()
+    params: {
+      roleDefinitionId: roleDefinitionId
+      principalId: principalId
+    }
+  }
+*/
+
+targetScope = 'subscription'
+
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+param roleDefinitionId string = ''
+param principalId string = ''
+
+var name_roleAssignmentName = guid('${subscription().id}${principalId}Role assignment in subscription scope')
+
+// Get role resource id in subscription
+resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  name: roleDefinitionId
+}
+
+// Assign role
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+  name: name_roleAssignmentName
+  properties: {
+    description: 'Assign subscription scope role to User Assigned Managed Identity '
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: roleResourceDefinition.id
+  }
+}

--- a/src/main/bicep/modules/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uamiAndRoles.bicep
@@ -1,0 +1,40 @@
+/*
+     Copyright (c) Microsoft Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param location string
+
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+var const_roleDefinitionIdOfOwner = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
+var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity'
+var name_deploymentScriptOwnerRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+
+// UAMI for deployment script
+resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@2021-09-30-preview' = {
+  name: name_deploymentScriptUserDefinedManagedIdentity
+  location: location
+}
+
+// Assign Owner role in subscription scope, we need the permission to get/update resource cross resource group.
+module deploymentScriptUAMICotibutorRoleAssignment '_rolesAssignment/_roleAssignmentinSubscription.bicep' = {
+  name: name_deploymentScriptOwnerRoleAssignmentName
+  scope: subscription()
+  params: {
+    roleDefinitionId: const_roleDefinitionIdOfOwner
+    principalId: reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', name_deploymentScriptUserDefinedManagedIdentity)).principalId
+  }
+}
+
+output uamiIdForDeploymentScript string = uamiForDeploymentScript.id

--- a/src/main/bicep/modules/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uamiAndRoles.bicep
@@ -17,9 +17,9 @@
 param location string
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-var const_roleDefinitionIdOfOwner = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
+var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptOwnerRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@2021-09-30-preview' = {
@@ -27,12 +27,12 @@ resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentiti
   location: location
 }
 
-// Assign Owner role in subscription scope, we need the permission to get/update resource cross resource group.
+// Assign Contributor role in subscription scope, we need the permission to get/update resource cross resource groups.
 module deploymentScriptUAMICotibutorRoleAssignment '_rolesAssignment/_roleAssignmentinSubscription.bicep' = {
-  name: name_deploymentScriptOwnerRoleAssignmentName
+  name: name_deploymentScriptContributorRoleAssignmentName
   scope: subscription()
   params: {
-    roleDefinitionId: const_roleDefinitionIdOfOwner
+    roleDefinitionId: const_roleDefinitionIdOfContributor
     principalId: reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', name_deploymentScriptUserDefinedManagedIdentity)).principalId
   }
 }

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -158,11 +158,6 @@ apk add docker-cli
 az aks install-cli 2>/dev/null
 az aks get-credentials -g $clusterRGName -n $clusterName --overwrite-existing >> $logFile
 
-# Assign AcrPull role to the kubelet identity of the AKS cluster
-AKS_IDENTITY_ID=$(az aks show -g $clusterRGName -n $clusterName --query "identityProfile.kubeletidentity.objectId" --output tsv)
-ACR_ID=$(az acr show -n $acrName --query id -o tsv)
-az role assignment create --assignee-object-id $AKS_IDENTITY_ID --scope $ACR_ID --role acrpull >> $logFile
-
 # Install Open Liberty Operator
 OPERATOR_VERSION=0.8.2
 mkdir -p overlays/watch-all-namespaces

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -261,3 +261,6 @@ if [ "$deployApplication" = True ] && [ "$ENABLE_APP_GW_INGRESS" = False ]; then
 fi
 echo "Result is: $result" >> $logFile
 echo $result > $AZ_SCRIPTS_OUTPUT_PATH
+
+# Delete uami generated before
+az identity delete --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -158,8 +158,10 @@ apk add docker-cli
 az aks install-cli 2>/dev/null
 az aks get-credentials -g $clusterRGName -n $clusterName --overwrite-existing >> $logFile
 
-# Attach the acr instance to the AKS cluster
-az aks update -g $clusterRGName -n $clusterName --attach-acr $acrName >> $logFile
+# Assign AcrPull role to the kubelet identity of the AKS cluster
+AKS_IDENTITY_ID=$(az aks show -g $clusterRGName -n $clusterName --query "identityProfile.kubeletidentity.objectId" --output tsv)
+ACR_ID=$(az acr show -n $acrName --query id -o tsv)
+az role assignment create --assignee-object-id $AKS_IDENTITY_ID --scope $ACR_ID --role acrpull >> $logFile
 
 # Install Open Liberty Operator
 OPERATOR_VERSION=0.8.2

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -171,13 +171,6 @@ if [ ${roleLength} -ne 1 ]; then
     fi
 fi
 
-# Check if the user assigned managed identity has Directory readers role in the Azure AD
-az ad user list 1>/dev/null
-if [ $? == 1 ]; then
-    echo "The user-assigned managed identity must have Directory readers role in the Azure AD, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
-    exit 1
-fi
-
 if [[ "${ENABLE_APPLICATION_GATEWAY_INGRESS_CONTROLLER,,}" == "true" ]]; then
   validate_appgateway_vnet
   validate_gateway_frontend_certificates

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -160,11 +160,11 @@ fi
 # Query principal Id of the user-assigned managed identity
 principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "principalId" -o tsv)
 
-# Check if the user assigned managed identity has Owner role
+# Check if the user assigned managed identity has Contributor role
 roleAssignments=$(az role assignment list --assignee ${principalId})
-roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Owner") ] | length')
+roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Contributor") ] | length')
 if [ ${roleLength} -ne 1 ]; then
-  echo "The user-assigned managed identity must have the Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+  echo "The user-assigned managed identity must have the Contributor role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
   exit 1
 fi
 

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -160,15 +160,12 @@ fi
 # Query principal Id of the user-assigned managed identity
 principalId=$(az identity show --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY} --query "principalId" -o tsv)
 
-# Check if the user assigned managed identity has Owner role or Contributor and User Access Administrator roles.  For simplicity, the error message just declares Owner role. See https://github.com/WASdev/azure.liberty.aks/pull/31
+# Check if the user assigned managed identity has Owner role
 roleAssignments=$(az role assignment list --assignee ${principalId})
 roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Owner") ] | length')
 if [ ${roleLength} -ne 1 ]; then
-    roleLength=$(echo $roleAssignments | jq '[ .[] | select(.roleDefinitionName=="Contributor" or .roleDefinitionName=="User Access Administrator") ] | length')
-    if [ ${roleLength} -ne 2 ]; then
-        echo "The user-assigned managed identity must have the Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
-        exit 1
-    fi
+  echo "The user-assigned managed identity must have the Owner role in the subscription, please check ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}" >&2
+  exit 1
 fi
 
 if [[ "${ENABLE_APPLICATION_GATEWAY_INGRESS_CONTROLLER,,}" == "true" ]]; then


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #57

## Change summary

* Remove uami from user inputs
* Create a uami in ARM template and assign it with `Contributor` role
* Remove `--attach-acr` from deployment script which requires AAD role `Directory Readers` for the uami
* Assign `AcrPull` role to kubelet identity of the AKS cluster in the scope of resource group where the ACR instance is located
* The auto-generated uami will be deleted after the deployment

## Testing

The following test cases have already been passed before opening the PR:

* new aks cluster + new acr
* new aks cluster + new acr + sample app
* existing aks cluster + existing acr + sample app
* new aks cluster + new acr + agic
* new aks cluster + new acr + agic + sample app
* existing aks cluster + existing acr + agic + sample app

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for live testing.

## UI changes review

Besides visiting [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for reviewing new blade `Networking`, reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.txt](https://raw.githubusercontent.com/majguo/azure.liberty.aks/rm-uami/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- The UI changes are in the `Basic` tab, where the uami related UI components are replaced with an information box:

   > The Azure identity deploying this offer must have one of the following two sets of Azure role-based access control roles:
   > * [Contributor](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles?WT.mc_id=Portal-Microsoft_Azure_CreateUIDef#contributor) and [User Access Administrator](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles?WT.mc_id=Portal-Microsoft_Azure_CreateUIDef#user-access-administrator) of the current subscription.
   > * [Owner](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles?WT.mc_id=Portal-Microsoft_Azure_CreateUIDef#owner) of the current subscription.

Here is the screenshot of UI changes:
![image](https://user-images.githubusercontent.com/10357495/182822769-bcf1d1d6-8378-4dd9-9f2d-b6ac35b71f30.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>