### PR TITLE
Upgrade versions of external deps used in pipelines by referencing to the centralized config file

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -115,10 +115,10 @@ jobs:
             echo "Invalid value of appHttpEndpoint: ${appHttpEndpoint}"
             exit 1
           fi
-          appHttpsEndoint=$(echo $outputs | jq -r '.appHttpsEndoint.value')
-          echo "appHttpsEndoint: ${appHttpsEndoint}"
-          if [[ $enableAppGWIngress == "true" && -z "$appHttpsEndoint" ]] || [[ $enableAppGWIngress == "false" && -n "$appHttpsEndoint" ]]; then
-            echo "Invalid value of appHttpsEndoint: ${appHttpsEndoint}"
+          appHttpsEndpoint=$(echo $outputs | jq -r '.appHttpsEndpoint.value')
+          echo "appHttpsEndpoint: ${appHttpsEndpoint}"
+          if [[ $enableAppGWIngress == "true" && -z "$appHttpsEndpoint" ]] || [[ $enableAppGWIngress == "false" && -n "$appHttpsEndpoint" ]]; then
+            echo "Invalid value of appHttpsEndpoint: ${appHttpsEndpoint}"
             exit 1
           fi
           curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
@@ -127,9 +127,9 @@ jobs:
             exit 1
           fi
           if [[ $enableAppGWIngress == "true" ]]; then
-            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndoint -k
+            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndpoint -k
             if [[ $? -ne 0 ]]; then
-              echo "Failed to access ${appHttpsEndoint}."
+              echo "Failed to access ${appHttpsEndpoint}."
               exit 1
             fi
           fi

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,9 +37,6 @@ on:
   # Disable AGIC and keep Azure resources at the end
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": false, "deleteAzureResources": false}}'
 env:
-
-  # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
-  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.liberty.aks"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   isInternalSub: ${{ secrets.IS_INTERNAL_SUBSCRIPTION }}
@@ -54,11 +51,12 @@ jobs:
     steps:
       - name: Get versions of external dependencies
         run: |
-          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
           echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -39,7 +39,6 @@ on:
 env:
   repoName: "azure.liberty.aks"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
-  isInternalSub: ${{ secrets.IS_INTERNAL_SUBSCRIPTION }}
   userName: ${{ secrets.USER_NAME }}
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   testResourceGroup: libertyAksTestRG${{ github.run_id }}${{ github.run_number }}
@@ -122,18 +121,16 @@ jobs:
             echo "Invalid value of appHttpsEndoint: ${appHttpsEndoint}"
             exit 1
           fi
-          if [[ "${{ env.isInternalSub }}" == "false" ]]; then 
-            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
+          curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${appHttpEndpoint}."
+            exit 1
+          fi
+          if [[ $enableAppGWIngress == "true" ]]; then
+            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndoint -k
             if [[ $? -ne 0 ]]; then
-              echo "Failed to access ${appHttpEndpoint}."
+              echo "Failed to access ${appHttpsEndoint}."
               exit 1
-            fi
-            if [[ $enableAppGWIngress == "true" ]]; then
-              curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndoint -k
-              if [[ $? -ne 0 ]]; then
-                echo "Failed to access ${appHttpsEndoint}."
-                exit 1
-              fi
             fi
           fi
       - name: Debugging with tmate if verification failed

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -38,12 +38,12 @@ on:
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": false, "deleteAzureResources": false}}'
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.31.0
+  azCliVersion: 2.40.0
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.7.4
+  bicepVersion: v0.11.1
   repoName: "azure.liberty.aks"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   isInternalSub: ${{ secrets.IS_INTERNAL_SUBSCRIPTION }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -40,7 +40,7 @@ env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
   azCliVersion: 2.40.0
   # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
+  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   bicepVersion: v0.11.1

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,13 +37,9 @@ on:
   # Disable AGIC and keep Azure resources at the end
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": false, "deleteAzureResources": false}}'
 env:
-  # Latest version is at https://github.com/Azure/azure-cli/releases
-  azCliVersion: 2.40.0
-  # Commit hash from https://github.com/Azure/arm-ttk/commits/master
-  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
+
   # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
-  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.11.1
+  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.liberty.aks"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
   isInternalSub: ${{ secrets.IS_INTERNAL_SUBSCRIPTION }}
@@ -56,6 +52,13 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,7 +12,6 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aks
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.liberty.aks"
 
 jobs:
@@ -21,11 +20,12 @@ jobs:
     steps:
       - name: Get versions of external dependencies
         run: |
-          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
           echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
+          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,9 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aks
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.7.4
+  bicepVersion: v0.11.1
   repoName: "azure.liberty.aks"
 
 jobs:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,15 +12,20 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aks
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
-  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
-  bicepVersion: v0.11.1
+  refJavaee: b728442f1921282f5f3902fe5bdf7f4d2c7872ca
   repoName: "azure.liberty.aks"
 
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
+      - name: Get versions of external dependencies
+        run: |
+          curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/external-deps-versions.properties
+          source external-deps-versions.properties
+          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
+          echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
+          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,7 +12,7 @@ on:
   # REPO_NAME=WASdev/azure.liberty.aks
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
-  refArmttk: b98c03608a20bbee4f2061b23bdeece1c2d214b8
+  refArmttk: 06356206f9a8a5173fc124458a1486a1cc67fa31
   refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
   bicepVersion: v0.11.1
   repoName: "azure.liberty.aks"

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -27,8 +27,6 @@ DISAMBIG_PREFIX=
 USER_NAME=
 # Owner/reponame, e.g., <USER_NAME>/azure.liberty.aks
 OWNER_REPONAME=
-# Set to true if your subscription is a Microsoft internal subscription
-IS_INTERNAL_SUBSCRIPTION=
 # Optional: Web hook for Microsoft Teams channel
 MSTEAMS_WEBHOOK=
 
@@ -81,11 +79,6 @@ if [ -z "${OWNER_REPONAME}" ] ; then
     GH_FLAGS=""
 else
     GH_FLAGS="--repo ${OWNER_REPONAME}"
-fi
-
-# get IS_INTERNAL_SUBSCRIPTION if not set at the beginning of this file
-if [ "$IS_INTERNAL_SUBSCRIPTION" == '' ] ; then
-    read -r -p "Enter true if your subscription is a Microsoft internal subscription, otherwise enter false: " IS_INTERNAL_SUBSCRIPTION
 fi
 
 # Optional: get MSTEAMS_WEBHOOK if not set at the beginning of this file
@@ -146,7 +139,6 @@ if $USE_GITHUB_CLI; then
     msg "${YELLOW}\"AZURE_CREDENTIALS\""
     msg "${GREEN}${AZURE_CREDENTIALS}"
     gh ${GH_FLAGS} secret set USER_NAME -b"${USER_NAME}"
-    gh ${GH_FLAGS} secret set IS_INTERNAL_SUBSCRIPTION -b"${IS_INTERNAL_SUBSCRIPTION}"
     gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
     msg "${YELLOW}\"DISAMBIG_PREFIX\""
     msg "${GREEN}${DISAMBIG_PREFIX}"
@@ -165,8 +157,6 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${GREEN}${AZURE_CREDENTIALS}"
   msg "${YELLOW}\"USER_NAME\""
   msg "${GREEN}${USER_NAME}"
-  msg "${YELLOW}\"IS_INTERNAL_SUBSCRIPTION\""
-  msg "${GREEN}${IS_INTERNAL_SUBSCRIPTION}"
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${GREEN}${MSTEAMS_WEBHOOK}"
   msg "${NOFORMAT}========================================================================"

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -74,7 +74,6 @@ if $USE_GITHUB_CLI; then
     msg "${GREEN}Using the GitHub CLI to remove secrets.${NOFORMAT}"
     gh ${GH_FLAGS} secret remove AZURE_CREDENTIALS
     gh ${GH_FLAGS} secret remove USER_NAME
-    gh ${GH_FLAGS} secret remove IS_INTERNAL_SUBSCRIPTION
     gh ${GH_FLAGS} secret remove MSTEAMS_WEBHOOK
     msg "${GREEN}Secrets removed"
   } || {
@@ -89,7 +88,6 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "(in ${YELLOW}yellow the secret name)"
   msg "${YELLOW}\"AZURE_CREDENTIALS\""
   msg "${YELLOW}\"USER_NAME\""
-  msg "${YELLOW}\"IS_INTERNAL_SUBSCRIPTION\""
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${NOFORMAT}========================================================================"
 fi

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@
    1. Open the resource group `resourceGroupName`;
    1. Navigate to "Deployments > `deploymentName` > Outputs";
    1. Copy value of property `appHttpEndpoint` > append context root defined in the 'server.xml' of your application if it's not equal to '/' > open it in the browser;
-   1. If you enabled AGIC: copy value of property `appHttpsEndoint` > append context root defined in the 'server.xml' of your application if it's not equal to '/' > open it in the browser;
+   1. If you enabled AGIC: copy value of property `appHttpsEndpoint` > append context root defined in the 'server.xml' of your application if it's not equal to '/' > open it in the browser;

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.28</version>
+    <version>1.0.29</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.18</version>
         <relativePath></relativePath>
     </parent>
     

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -488,6 +488,8 @@ module aksEndPid './modules/_pids/_empty.bicep' = {
 }
 
 output appHttpEndpoint string = deployApplication ? (enableAppGWIngress ? appgwDeployment.outputs.appGatewayURL : primaryDsDeployment.outputs.appEndpoint ) : ''
+output appHttpsEndpoint string = deployApplication && enableAppGWIngress ? appgwDeployment.outputs.appGatewaySecuredURL : ''
+// Must copy code rather than reference appHttpsEndpoint. See https://github.com/Azure/bicep/issues/8710
 output appHttpsEndoint string = deployApplication && enableAppGWIngress ? appgwDeployment.outputs.appGatewaySecuredURL : ''
 output clusterName string = name_clusterName
 output clusterRGName string = const_clusterRGName

--- a/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_acrPullRoleAssignment.bicep
@@ -34,7 +34,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2021-09-01' existing = {
 }
 
 // https://github.com/Azure/azure-quickstart-templates/issues/4205
-resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid('${aksCluster.id}${acr.id}ForKubeletIdentity')
   properties: {
     description: 'Assign Resource Group Contributor role to User Assigned Managed Identity '

--- a/src/main/bicep/modules/_rolesAssignment/_agicRoleAssignment.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_agicRoleAssignment.bicep
@@ -28,7 +28,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-02-01' exis
   scope: resourceGroup(aksClusterRGName)
 }
 
-resource agicUamiRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+resource agicUamiRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: name_appGwContributorRoleAssignmentName
   properties: {
     description: 'Assign Resource Group Contributor role to User Assigned Managed Identity '

--- a/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
+++ b/src/main/bicep/modules/_rolesAssignment/_roleAssignmentinSubscription.bicep
@@ -41,7 +41,7 @@ resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@2018-01
 }
 
 // Assign role
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: name_roleAssignmentName
   properties: {
     description: 'Assign subscription scope role to User Assigned Managed Identity '


### PR DESCRIPTION
Upgrade versions of external deps used in pipelines by referencing to the centralized config file:
- az-cli
- bicep
- arm-ttk
- azure-javaee-iaas

The other changes:
- upgrade to `Microsoft.Authorization/roleAssignments@2022-04-01`
- remove pipeline env `IS_INTERNAL_SUBSCRIPTION`
- correct typo `appHttpsEndoint` as `appHttpsEndpoint` from deployment outputs

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>