### PR TITLE
Support WebSphere Liberty Operator

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -109,7 +109,7 @@ jobs:
         id: azure-login
         with:
           creds: ${{ env.azureCredentials }}
-      - name: Deploy an Open Liberty Application sample app on AKS
+      - name: Start the deployment
         run: |
           cd ${{ env.repoName }}/target/cli
           chmod a+x deploy.azcli

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -119,29 +119,35 @@ jobs:
           outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
           appHttpEndpoint=$(echo $outputs | jq -r '.appHttpEndpoint.value')
           echo "appHttpEndpoint: ${appHttpEndpoint}"
-          if [[ $deployApplication == "true" && -z "$appHttpsEndpoint" ]] || [[ $deployApplication == "false" && -n "$appHttpEndpoint" ]]; then
-            echo "Invalid value of appHttpEndpoint: ${appHttpEndpoint}"
-            exit 1
-          fi
           appHttpsEndpoint=$(echo $outputs | jq -r '.appHttpsEndpoint.value')
           echo "appHttpsEndpoint: ${appHttpsEndpoint}"
-          if [[ $enableAppGWIngress == "true" && -z "$appHttpsEndpoint" ]] || [[ $enableAppGWIngress == "false" && -n "$appHttpsEndpoint" ]]; then
-            echo "Invalid value of appHttpsEndpoint: ${appHttpsEndpoint}"
-            exit 1
-          fi
           if [[ $deployApplication == "true" ]]; then
+            if [[ -z "$appHttpEndpoint" ]]; then
+              echo "Invalid value of appHttpEndpoint: ${appHttpEndpoint}"
+              exit 1
+            fi
             curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
             if [[ $? -ne 0 ]]; then
               echo "Failed to access ${appHttpEndpoint}."
               exit 1
             fi
+          elif [[ -n "$appHttpEndpoint" ]]; then
+            echo "Invalid value of appHttpEndpoint: ${appHttpEndpoint}"
+            exit 1
           fi
           if [[ $deployApplication == "true" && $enableAppGWIngress == "true" ]]; then
+            if [[ -z "$appHttpsEndpoint" ]]; then
+              echo "Invalid value of appHttpsEndpoint: ${appHttpsEndpoint}"
+              exit 1
+            fi
             curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndpoint -k
             if [[ $? -ne 0 ]]; then
               echo "Failed to access ${appHttpsEndpoint}."
               exit 1
             fi
+          elif [[ -n "$appHttpsEndpoint" ]]; then
+            echo "Invalid value of appHttpsEndpoint: ${appHttpsEndpoint}"
+            exit 1 
           fi
       - name: Debugging with tmate if verification failed
         if: failure()

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,35 +7,33 @@ on:
         required: true
         type: boolean
         default: true
+      deployWLO:
+        description: 'WebSphere Liberty operator'
+        required: true
+        type: boolean
+        default: false
+      deployApplication:
+        description: 'Sample application'
+        required: true
+        type: boolean
+        default: true
       deleteAzureResources:
         description: 'Delete Azure resources at the end'
         required: true
         type: boolean
         default: true
-  # Allows you to run this workflow using GitHub APIs
+  # Allows you to run this workflow using GitHub workflow dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aks
-  # Enable AGIC and delete Azure resources at the end
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main"}'
-  # Enable AGIC and keep Azure resources at the end
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"deleteAzureResources": "false"}}'
-  # Disable AGIC and delete Azure resources at the end
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"enableAppGWIngress": "false"}}'
-  # Disable AGIC and keep Azure resources at the end
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"enableAppGWIngress": "false", "deleteAzureResources": "false"}}'
+  # Enable/disable AGIC, WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"enableAppGWIngress": "true|false", "deployWLO": "true|false", "deployApplication": "true|false", "deleteAzureResources": "true|false"}}'
   repository_dispatch:
     types: [integration-test]
-  # sample request
+  # Allows you to run this workflow using GitHub repository dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aks
-  # Enable AGIC and delete Azure resources at the end
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": true, "deleteAzureResources": true}}'
-  # Enable AGIC and keep Azure resources at the end
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": true, "deleteAzureResources": false}}'
-  # Disable AGIC and delete Azure resources at the end
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": false, "deleteAzureResources": true}}'
-  # Disable AGIC and keep Azure resources at the end
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": false, "deleteAzureResources": false}}'
+  # Enable/disable AGIC, WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": true|false, "deployWLO": true|false, "deployApplication": true|false, "deleteAzureResources": true|false}}'
 env:
   repoName: "azure.liberty.aks"
   azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
@@ -92,10 +90,20 @@ jobs:
             enableAppGWIngress=true
           fi
           echo "enableAppGWIngress=${enableAppGWIngress}" >> $GITHUB_ENV
+          deployWLO=false
+          if ${{ inputs.deployWLO == true || github.event.client_payload.deployWLO == true }}; then
+            deployWLO=true
+          fi
+          deployApplication=false
+          if ${{ inputs.deployApplication == true || github.event.client_payload.deployApplication == true }}; then
+            deployApplication=true
+          fi
+          echo "deployApplication=${deployApplication}" >> $GITHUB_ENV
           cd ${{ env.repoName }}
           mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DcreateCluster=true -DcreateACR=true \
             -DenableAppGWIngress=${enableAppGWIngress} -DappgwUsePrivateIP=false -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true \
-            -DdeployApplication=true -DappImagePath=icr.io/appcafe/open-liberty/samples/getting-started -DappReplicas=2 \
+            -DdeployWLO=${deployWLO} -Dedition="IBM WebSphere Application Server" -DproductEntitlementSource="Standalone" \
+            -DdeployApplication=${deployApplication} -DappImagePath=icr.io/appcafe/open-liberty/samples/getting-started -DappReplicas=2 \
             -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       - uses: azure/login@v1
         id: azure-login
@@ -111,7 +119,7 @@ jobs:
           outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
           appHttpEndpoint=$(echo $outputs | jq -r '.appHttpEndpoint.value')
           echo "appHttpEndpoint: ${appHttpEndpoint}"
-          if [[ -z "$appHttpEndpoint" ]]; then
+          if [[ $deployApplication == "true" && -z "$appHttpsEndpoint" ]] || [[ $deployApplication == "false" && -n "$appHttpEndpoint" ]]; then
             echo "Invalid value of appHttpEndpoint: ${appHttpEndpoint}"
             exit 1
           fi
@@ -121,12 +129,14 @@ jobs:
             echo "Invalid value of appHttpsEndpoint: ${appHttpsEndpoint}"
             exit 1
           fi
-          curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
-          if [[ $? -ne 0 ]]; then
-            echo "Failed to access ${appHttpEndpoint}."
-            exit 1
+          if [[ $deployApplication == "true" ]]; then
+            curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpEndpoint
+            if [[ $? -ne 0 ]]; then
+              echo "Failed to access ${appHttpEndpoint}."
+              exit 1
+            fi
           fi
-          if [[ $enableAppGWIngress == "true" ]]; then
+          if [[ $deployApplication == "true" && $enableAppGWIngress == "true" ]]; then
             curl --verbose --connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused $appHttpsEndpoint -k
             if [[ $? -ne 0 ]]; then
               echo "Failed to access ${appHttpsEndpoint}."

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: true
       deployWLO:
-        description: 'WebSphere Liberty operator'
+        description: 'WebSphere Liberty Operator'
         required: true
         type: boolean
         default: false

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -25,14 +25,14 @@ on:
   # Allows you to run this workflow using GitHub workflow dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aks
-  # Enable/disable AGIC, WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # Enable/disable AGIC, WebSphere Liberty Operator and sample application. Keep/delete Azure resources at the end.
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"enableAppGWIngress": "true|false", "deployWLO": "true|false", "deployApplication": "true|false", "deleteAzureResources": "true|false"}}'
   repository_dispatch:
     types: [integration-test]
   # Allows you to run this workflow using GitHub repository dispatch APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aks
-  # Enable/disable AGIC, WebSphere Liberty operator and sample application. Keep/delete Azure resources at the end.
+  # Enable/disable AGIC, WebSphere Liberty Operator and sample application. Keep/delete Azure resources at the end.
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"enableAppGWIngress": true|false, "deployWLO": true|false, "deployApplication": true|false, "deleteAzureResources": true|false}}'
 env:
   repoName: "azure.liberty.aks"

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -125,7 +125,10 @@ USE_GITHUB_CLI=false
 msg "${GREEN}(3/4) Create service principal ${SERVICE_PRINCIPAL_NAME}"
 SUBSCRIPTION_ID=$(az account show --query id --output tsv --only-show-errors)
 SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --name ${SERVICE_PRINCIPAL_NAME} --role="Contributor" --scopes="/subscriptions/${SUBSCRIPTION_ID}" --sdk-auth --only-show-errors | base64 -w0)
-SP_ID=$( az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [0].id -o tsv)
+msg "${YELLOW}\"DISAMBIG_PREFIX\""
+msg "${GREEN}${DISAMBIG_PREFIX}"
+
+SP_ID=$(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME --query [0].id -o tsv)
 az role assignment create --assignee ${SP_ID} --role "User Access Administrator"
 
 # Create GitHub action secrets
@@ -140,8 +143,6 @@ if $USE_GITHUB_CLI; then
     msg "${GREEN}${AZURE_CREDENTIALS}"
     gh ${GH_FLAGS} secret set USER_NAME -b"${USER_NAME}"
     gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
-    msg "${YELLOW}\"DISAMBIG_PREFIX\""
-    msg "${GREEN}${DISAMBIG_PREFIX}"
     msg "${GREEN}Secrets configured"
   } || {
     USE_GITHUB_CLI=false

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@
    1. Create a new AKS cluster and a new Azure Container Registry (ACR) instance with Application Gateway Ingress Controller (AGIC) enabled:
 
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=true -DcreateACR=true -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=true -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=true -DcreateACR=true -DdeployWLO=<true|false> -Dedition=<edition> -DproductEntitlementSource=<productEntitlementSource> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=true -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       ```
 
    1. Or use an existing AKS cluster and an existing ACR instance without AGIC:
 
       ```bash
-      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DacrRGName=<acr-group-name> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DcreateCluster=false -DclusterName=<aks-cluster-name> -DclusterRGName=<cluster-group-name> -DcreateACR=false -DacrName=<acr-instance-name> -DacrRGName=<acr-group-name> -DdeployWLO=<true|false> -Dedition=<edition> -DproductEntitlementSource=<productEntitlementSource> -DdeployApplication=<true|false> -DappImagePath=<app-image-path> -DappReplicas=<number of replicas> -DenableAppGWIngress=false -DappgwUsePrivateIP=<true|false> -DappGatewayCertificateOption=generateCert -DenableCookieBasedAffinity=true -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       ```
 
 1. Change to `./target/cli` directory

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.29</version>
+    <version>1.0.30</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -510,13 +510,33 @@
                         }
                     },
                     {
+                        "name": "deployApplication",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Deploy an application?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to deploy an application, or select 'No' if you prefer to manually deploy application later.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
                         "name": "licenseInfo",
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
                             "icon": "Info",
                             "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "acceptIBMLicenseAgreement",
@@ -527,7 +547,7 @@
                             "required": true,
                             "validationMessage": "The deployment will not proceed unless you accept the License Agreement."
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "edition",
@@ -552,7 +572,7 @@
                             ],
                             "required": true
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "productEntitlementSource",
@@ -581,27 +601,7 @@
                             ],
                             "required": true
                         },
-                        "visible": "[bool(steps('Application').deployWLO)]"
-                    },
-                    {
-                        "name": "deployApplication",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Deploy an application?",
-                        "defaultValue": "No",
-                        "toolTip": "Select 'Yes' to deploy an application, or select 'No' if you prefer to manually deploy application later.",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "Yes",
-                                    "value": "true"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "false"
-                                }
-                            ],
-                            "required": true
-                        }
+                        "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
                     {
                         "name": "appImageInfo",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -575,8 +575,8 @@
                                     "value": "IBM Cloud Pak for Applications"
                                 },
                                 {
-                                    "label": "IBM WebSphere Server Family Edition",
-                                    "value": "IBM WebSphere Server Family Edition"
+                                    "label": "IBM WebSphere Application Server Family Edition",
+                                    "value": "IBM WebSphere Application Server Family Edition"
                                 }
                             ],
                             "required": true

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -532,6 +532,7 @@
                     {
                         "name": "edition",
                         "type": "Microsoft.Common.OptionsGroup",
+                        "defaultValue": "IBM WebSphere Application Server",
                         "label": "Edition",
                         "toolTip": "Product edition",
                         "constraints": {
@@ -556,6 +557,7 @@
                     {
                         "name": "productEntitlementSource",
                         "type": "Microsoft.Common.OptionsGroup",
+                        "defaultValue": "Standalone",
                         "label": "Product entitlement source",
                         "toolTip": "Entitlement source for the product",
                         "constraints": {

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -482,13 +482,105 @@
             },
             {
                 "name": "Application",
-                "label": "Configure application",
+                "label": "Operator and application",
                 "subLabel": {
-                    "preValidation": "Provide required info for application",
+                    "preValidation": "Provide required info for Operator and application",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Configure application",
+                "bladeTitle": "Operator and application",
                 "elements": [
+                    {
+                        "name": "deployWLO",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "IBM supported?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' if your deployments are to be supported under existing WebSphere entitlements (this includes supported deployments of Open Liberty). Select 'Yes' if you are deploying WebSphere Liberty under the Trial license terms. Select 'No' if you are deploying Open Liberty unsupported.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "licenseInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "acceptIBMLicenseAgreement",
+                        "type": "Microsoft.Common.CheckBox",
+                        "label": "Accept license",
+                        "toolTip": "Select to accept the License Agreement.",
+                        "constraints": {
+                            "required": true,
+                            "validationMessage": "The deployment will not proceed unless you accept the License Agreement."
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "edition",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Edition",
+                        "toolTip": "Product edition",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "IBM WebSphere Application Server",
+                                    "value": "IBM WebSphere Application Server"
+                                },
+                                {
+                                    "label": "IBM WebSphere Application Server Liberty Core",
+                                    "value": "IBM WebSphere Application Server Liberty Core"
+                                },
+                                {
+                                    "label": "IBM WebSphere Application Server Network Deployment",
+                                    "value": "IBM WebSphere Application Server Network Deployment"
+                                }
+                            ],
+                            "required": true
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
+                    {
+                        "name": "productEntitlementSource",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Product entitlement source",
+                        "toolTip": "Entitlement source for the product",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Standalone",
+                                    "value": "Standalone"
+                                },
+                                {
+                                    "label": "IBM WebSphere Hybrid Edition",
+                                    "value": "IBM WebSphere Hybrid Edition"
+                                },
+                                {
+                                    "label": "IBM Cloud Pak for Applications",
+                                    "value": "IBM Cloud Pak for Applications"
+                                },
+                                {
+                                    "label": "IBM WebSphere Server Family Edition",
+                                    "value": "IBM WebSphere Server Family Edition"
+                                }
+                            ],
+                            "required": true
+                        },
+                        "visible": "[bool(steps('Application').deployWLO)]"
+                    },
                     {
                         "name": "deployApplication",
                         "type": "Microsoft.Common.OptionsGroup",
@@ -607,6 +699,9 @@
             "keyVaultSSLCertDataSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertDataSecretName]",
             "keyVaultSSLCertPasswordSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertPasswordSecretName]",
             "enableCookieBasedAffinity": "[bool(steps('section_appGateway').appgwIngress.enableCookieBasedAffinity)]",
+            "deployWLO": "[bool(steps('Application').deployWLO)]",
+            "edition": "[steps('Application').edition]",
+            "productEntitlementSource": "[steps('Application').productEntitlementSource]",
             "deployApplication": "[bool(steps('Application').deployApplication)]",
             "appImagePath": "[if(equals(steps('Application').appImageInfo.appImageOption, '2'), 'icr.io/appcafe/open-liberty/samples/getting-started', if(equals(steps('Application').appImageInfo.appImageOption, '3'), 'docker.io/ibmcom/websphere-liberty-sample:1.0.0', steps('Application').appImageInfo.appImagePath))]",
             "appReplicas": "[int(steps('Application').appLoadBalancingInfo.appReplicas)]"

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -53,6 +53,15 @@
         "enableCookieBasedAffinity": {
             "value": "${enableCookieBasedAffinity}"
         },
+        "deployWLO": {
+            "value": "${deployWLO}"
+        },
+        "edition": {
+            "value": "${edition}"
+        },
+        "productEntitlementSource": {
+            "value": "${productEntitlementSource}"
+        },
         "deployApplication": {
             "value": "${deployApplication}"
         },

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -118,6 +118,26 @@ param keyVaultSSLCertPasswordSecretName string = 'kv-ssl-psw'
 @description('true to enable cookie based affinity.')
 param enableCookieBasedAffinity bool = false
 
+@description('Flag indicating whether to deploy WebSphere Liberty operator.')
+param deployWLO bool = false
+
+@allowed([
+  'IBM WebSphere Application Server'
+  'IBM WebSphere Application Server Liberty Core'
+  'IBM WebSphere Application Server Network Deployment'
+])
+@description('Product edition')
+param edition string = 'IBM WebSphere Application Server'
+
+@allowed([
+  'Standalone'
+  'IBM WebSphere Hybrid Edition'
+  'IBM Cloud Pak for Applications'
+  'IBM WebSphere Server Family Edition'
+])
+@description('Entitlement source for the product')
+param productEntitlementSource string = 'Standalone'
+
 @description('Flag indicating whether to deploy an application')
 param deployApplication bool = false
 
@@ -149,6 +169,7 @@ var const_availabilityZones = [
 var const_azureSubjectName = format('{0}.{1}.{2}', name_dnsNameforApplicationGateway, location, 'cloudapp.azure.com')
 var const_clusterRGName = (createCluster ? resourceGroup().name : clusterRGName)
 var const_cmdToGetAcrLoginServer = format('az acr show -n {0} --query loginServer -o tsv', name_acrName)
+var const_metric = productEntitlementSource == 'Standalone' || productEntitlementSource == 'IBM WebSphere Server Family Edition' ? 'Processor Value Unit (PVU)' : 'Virtual Processor Core (VPC)'
 var const_newVnet = (vnetForApplicationGateway.newOrExisting == 'new') ? true : false
 var const_regionsSupportAvailabilityZones = [
   'australiaeast'
@@ -467,6 +488,10 @@ module primaryDsDeployment 'modules/_deployment-scripts/_ds-primary.bicep' = {
     _artifactsLocationSasToken: _artifactsLocationSasToken
     identity: obj_uamiForDeploymentScript
     arguments: const_arguments
+    deployWLO: deployWLO
+    edition: edition
+    productEntitlementSource: productEntitlementSource
+    metric: const_metric
     deployApplication: deployApplication
     enableAppGWIngress: enableAppGWIngress
     appFrontendTlsSecretName: const_appFrontendTlsSecretName

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -118,7 +118,7 @@ param keyVaultSSLCertPasswordSecretName string = 'kv-ssl-psw'
 @description('true to enable cookie based affinity.')
 param enableCookieBasedAffinity bool = false
 
-@description('Flag indicating whether to deploy WebSphere Liberty operator.')
+@description('Flag indicating whether to deploy WebSphere Liberty Operator.')
 param deployWLO bool = false
 
 @allowed([

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -514,8 +514,6 @@ module aksEndPid './modules/_pids/_empty.bicep' = {
 
 output appHttpEndpoint string = deployApplication ? (enableAppGWIngress ? appgwDeployment.outputs.appGatewayURL : primaryDsDeployment.outputs.appEndpoint ) : ''
 output appHttpsEndpoint string = deployApplication && enableAppGWIngress ? appgwDeployment.outputs.appGatewaySecuredURL : ''
-// Must copy code rather than reference appHttpsEndpoint. See https://github.com/Azure/bicep/issues/8710
-output appHttpsEndoint string = deployApplication && enableAppGWIngress ? appgwDeployment.outputs.appGatewaySecuredURL : ''
 output clusterName string = name_clusterName
 output clusterRGName string = const_clusterRGName
 output acrName string = name_acrName

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -133,7 +133,7 @@ param edition string = 'IBM WebSphere Application Server'
   'Standalone'
   'IBM WebSphere Hybrid Edition'
   'IBM Cloud Pak for Applications'
-  'IBM WebSphere Server Family Edition'
+  'IBM WebSphere Application Server Family Edition'
 ])
 @description('Entitlement source for the product')
 param productEntitlementSource string = 'Standalone'
@@ -169,7 +169,7 @@ var const_availabilityZones = [
 var const_azureSubjectName = format('{0}.{1}.{2}', name_dnsNameforApplicationGateway, location, 'cloudapp.azure.com')
 var const_clusterRGName = (createCluster ? resourceGroup().name : clusterRGName)
 var const_cmdToGetAcrLoginServer = format('az acr show -n {0} --query loginServer -o tsv', name_acrName)
-var const_metric = productEntitlementSource == 'Standalone' || productEntitlementSource == 'IBM WebSphere Server Family Edition' ? 'Processor Value Unit (PVU)' : 'Virtual Processor Core (VPC)'
+var const_metric = productEntitlementSource == 'Standalone' || productEntitlementSource == 'IBM WebSphere Application Server Family Edition' ? 'Processor Value Unit (PVU)' : 'Virtual Processor Core (VPC)'
 var const_newVnet = (vnetForApplicationGateway.newOrExisting == 'new') ? true : false
 var const_regionsSupportAvailabilityZones = [
   'australiaeast'

--- a/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
@@ -21,6 +21,10 @@ param location string
 param name string = ''
 param identity object = {}
 param arguments string = ''
+param deployWLO bool = false
+param edition string = 'IBM WebSphere Application Server'
+param productEntitlementSource string = 'Standalone'
+param metric string = 'Processor Value Unit (PVU)'
 param deployApplication bool = false
 param enableAppGWIngress bool = false
 param appFrontendTlsSecretName string =''
@@ -55,12 +59,30 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
         name: 'APP_GW_USE_PRIVATE_IP'
         value: string(appgwUsePrivateIP)
       }
+      {
+        name: 'DEPLOY_WLO'
+        value: string(deployWLO)
+      }
+      {
+        name: 'WLA_EDITION'
+        value: string(edition)
+      }
+      {
+        name: 'WLA_PRODUCT_ENTITLEMENT_SOURCE'
+        value: string(productEntitlementSource)
+      }
+      {
+        name: 'WLA_METRIC'
+        value: string(metric)
+      }
     ]
     arguments: arguments
     primaryScriptUri: uri(const_scriptLocation, 'install.sh${_artifactsLocationSasToken}')
     supportingScriptUris: [
       uri(const_scriptLocation, 'open-liberty-application.yaml.template${_artifactsLocationSasToken}')
       uri(const_scriptLocation, 'open-liberty-application-agic.yaml.template${_artifactsLocationSasToken}')
+      uri(const_scriptLocation, 'websphere-liberty-application.yaml.template${_artifactsLocationSasToken}')
+      uri(const_scriptLocation, 'websphere-liberty-application-agic.yaml.template${_artifactsLocationSasToken}')
     ]
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -122,6 +122,8 @@ appgwUsePrivateIP=$( echo $parametersJson | jq '.appgwUsePrivateIP.value' | sed 
 parametersJson=$( echo $parametersJson | jq --argjson appgwUsePrivateIP "$appgwUsePrivateIP" '.appgwUsePrivateIP.value = $appgwUsePrivateIP' )
 enableCookieBasedAffinity=$( echo $parametersJson | jq '.enableCookieBasedAffinity.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson enableCookieBasedAffinity "$enableCookieBasedAffinity" '.enableCookieBasedAffinity.value = $enableCookieBasedAffinity' )
+deployWLO=$( echo $parametersJson | jq '.deployWLO.value' | sed 's/"//g' )
+parametersJson=$( echo $parametersJson | jq --argjson deployWLO "$deployWLO" '.deployWLO.value = $deployWLO' )
 deployApplication=$( echo $parametersJson | jq '.deployApplication.value' | sed 's/"//g' )
 parametersJson=$( echo $parametersJson | jq --argjson deployApp "$deployApplication" '.deployApplication.value = $deployApp' )
 appReplicas=$( echo $parametersJson | jq '.appReplicas.value' | sed 's/"//g' )

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -47,7 +47,7 @@
 - Summary
   - Provisions IBM WebSphere Liberty on Azure Kubernetes Service
 - Long Summary
-  - Provisions IBM WebSphere Liberty on Azure Kubernetes Service with built in container registry, WAR/EAR deployment, and the Open Liberty Kubernetes operator.
+  - Provisions IBM WebSphere Liberty on Azure Kubernetes Service with built in container registry, WAR/EAR deployment, and the Open/WebSphere Liberty Kubernetes Operator.
 - Description
   - IBM WebSphere Liberty provides a flexible, secure server runtime environment for large-scale and mission critical application deployments. This offer provisions an IBM WebSphere Liberty environment on Azure Kubernetes Service.
 - Search Keywords
@@ -158,7 +158,7 @@
 - Summary
   - Provisions IBM WebSphere Liberty on Azure Kubernetes Service
 - Description
-  - Provisions IBM WebSphere Liberty on Azure Kubernetes Service with built in container registry, WAR/EAR deployment, and the Open Liberty Kubernetes operator.
+  - Provisions IBM WebSphere Liberty on Azure Kubernetes Service with built in container registry, WAR/EAR deployment, and the Open/WebSphere Liberty Kubernetes Operator.
 
 ### Availability
 

--- a/src/main/scripts/enableAgic.sh
+++ b/src/main/scripts/enableAgic.sh
@@ -24,7 +24,7 @@ function install_azure_ingress() {
         # After updating, your cluster's control plane and addon pods will switch to use managed identity, but kubelet will KEEP USING SERVICE PRINCIPAL until you upgrade your agentpool.
         az aks update -y -g ${AKS_CLUSTER_RG_NAME} -n ${AKS_CLUSTER_NAME} --enable-managed-identity
 
-        validate_status "Enable Applciation Gateway Ingress Controller for ${AKS_CLUSTER_NAME}."
+        validate_status "Enable managed identity for ${AKS_CLUSTER_NAME}."
     fi
 
     local agicEnabled=$(az aks show -n ${AKS_CLUSTER_NAME} -g ${AKS_CLUSTER_RG_NAME} | jq '.addonProfiles.ingressApplicationGateway.enabled')

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -190,7 +190,7 @@ else
 fi
 
 if [[ $? -ne 0 ]]; then
-  echo "Failed to install Open Liberty Operator, please check if required directories and files exist" >&2
+  echo "Failed to install Open/WebSphere Liberty Operator, please check if required directories and files exist" >&2
   exit 1
 fi
 wait_deployment_complete ${operatorDeploymentName} default ${logFile}
@@ -239,7 +239,7 @@ if [ "$deployApplication" = True ]; then
     fi
     Application_Image=${LOGIN_SERVER}/${Application_Image}
 
-    # Deploy open liberty application and output its base64 encoded deployment yaml file content
+    # Deploy open/websphere liberty application and output its base64 encoded deployment yaml file content
     envsubst < "$appDeploymentTemplate" > "$appDeploymentFile"
     appDeploymentYaml=$(cat $appDeploymentFile | base64)
     kubectl apply -f $appDeploymentFile >> $logFile
@@ -247,7 +247,7 @@ if [ "$deployApplication" = True ]; then
     # Wait until the application deployment completes
     wait_deployment_complete ${Application_Name} ${Project_Name} ${logFile}
     if [[ $? != 0 ]]; then
-        echo "The OpenLibertyApplication ${Application_Name} is not available." >&2
+        echo "The Open/WebSphere Liberty application ${Application_Name} is not available." >&2
         exit 1
     fi
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -159,17 +159,33 @@ apk add docker-cli
 az aks install-cli 2>/dev/null
 az aks get-credentials -g $clusterRGName -n $clusterName --overwrite-existing >> $logFile
 
-# Install Open Liberty Operator
-OPERATOR_VERSION=0.8.2
-mkdir -p overlays/watch-all-namespaces
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/overlays/watch-all-namespaces/olo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml -q -P ./overlays/watch-all-namespaces
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/overlays/watch-all-namespaces/kustomization.yaml -q -P ./overlays/watch-all-namespaces
-mkdir base
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/base/kustomization.yaml -q -P ./base
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/base/open-liberty-crd.yaml -q -P ./base
-wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OPERATOR_VERSION}/kustomize/base/open-liberty-operator.yaml -q -P ./base
-kubectl apply -k overlays/watch-all-namespaces
+if [ "$DEPLOY_WLO" = False ]; then
+    # Install Open Liberty Operator
+    OLO_VERSION=0.8.2
+    mkdir -p overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/overlays/watch-all-namespaces/olo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml -q -P ./overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/overlays/watch-all-namespaces/kustomization.yaml -q -P ./overlays/watch-all-namespaces
+    mkdir base
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/base/kustomization.yaml -q -P ./base
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/base/open-liberty-crd.yaml -q -P ./base
+    wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/base/open-liberty-operator.yaml -q -P ./base
+    kubectl apply -k overlays/watch-all-namespaces
+else
+    # Install WebSphere Liberty Operator
+    WLO_VERSION=1.0.2
+    mkdir -p overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml -q -P ./overlays/watch-all-namespaces
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/kustomization.yaml -q -P ./overlays/watch-all-namespaces
+    mkdir base
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/kustomization.yaml -q -P ./base
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-crd.yaml -q -P ./base
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-deployment.yaml -q -P ./base
+    wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-roles.yaml -q -P ./base
+    kubectl apply -k overlays/watch-all-namespaces
+fi
+
 if [[ $? -ne 0 ]]; then
   echo "Failed to install Open Liberty Operator, please check if required directories and files exist" >&2
   exit 1
@@ -193,14 +209,21 @@ PASSWORD=$(az acr credential show -n $acrName --query 'passwords[0].value' -o ts
 
 # Choose right template by checking if AGIC is enabled
 appDeploymentTemplate=open-liberty-application.yaml.template
-if [ "$ENABLE_APP_GW_INGRESS" = True ]; then
+if [ "$ENABLE_APP_GW_INGRESS" = True ] && [ "$DEPLOY_WLO" = True ]; then
+    appDeploymentTemplate=websphere-liberty-application-agic.yaml.template
+elif [ "$ENABLE_APP_GW_INGRESS" = True ] && [ "$DEPLOY_WLO" = False ]; then
     appDeploymentTemplate=open-liberty-application-agic.yaml.template
+elif [ "$ENABLE_APP_GW_INGRESS" = False ] && [ "$DEPLOY_WLO" = True ]; then
+    appDeploymentTemplate=websphere-liberty-application.yaml.template
 fi
 
 appDeploymentFile=open-liberty-application.yaml
 export Enable_Cookie_Based_Affinity="${ENABLE_COOKIE_BASED_AFFINITY,,}"
 export App_Gw_Use_Private_Ip="${APP_GW_USE_PRIVATE_IP,,}"
 export Frontend_Tls_Secret=${APP_FRONTEND_TLS_SECRET_NAME}
+export WLA_Edition="${WLA_EDITION}"
+export WLA_Product_Entitlement_Source="${WLA_PRODUCT_ENTITLEMENT_SOURCE}"
+export WLA_Metric="${WLA_METRIC}"
 
 # Deploy application image if it's requested by the user
 if [ "$deployApplication" = True ]; then
@@ -254,6 +277,9 @@ else
         | sed -e "s#\${Enable_Cookie_Based_Affinity}#${Enable_Cookie_Based_Affinity}#g" \
         | sed -e "s#\${App_Gw_Use_Private_Ip}#${App_Gw_Use_Private_Ip}#g" \
         | sed -e "s#\${Frontend_Tls_Secret}#${Frontend_Tls_Secret}#g" \
+        | sed -e "s#\${WLA_Edition}#${WLA_Edition}#g" \
+        | sed -e "s#\${WLA_Product_Entitlement_Source}#${WLA_Product_Entitlement_Source}#g" \
+        | sed -e "s#\${WLA_Metric}#${WLA_Metric}#g" \
         | base64)
 fi
 

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -157,7 +157,7 @@ apk add docker-cli
 
 # Install `kubectl` and connect to the AKS cluster
 az aks install-cli 2>/dev/null
-az aks get-credentials -g $clusterRGName -n $clusterName --overwrite-existing >> $logFile
+az aks get-credentials -g $clusterRGName -n $clusterName --admin --overwrite-existing >> $logFile
 
 operatorDeploymentName=
 if [ "$DEPLOY_WLO" = False ]; then

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -162,6 +162,7 @@ az aks get-credentials -g $clusterRGName -n $clusterName --admin --overwrite-exi
 operatorDeploymentName=
 if [ "$DEPLOY_WLO" = False ]; then
     # Install Open Liberty Operator
+    operatorDeploymentName=olo-controller-manager
     OLO_VERSION=0.8.2
     mkdir -p overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/overlays/watch-all-namespaces/olo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
@@ -172,9 +173,9 @@ if [ "$DEPLOY_WLO" = False ]; then
     wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/base/open-liberty-crd.yaml -q -P ./base
     wget https://raw.githubusercontent.com/OpenLiberty/open-liberty-operator/main/deploy/releases/${OLO_VERSION}/kustomize/base/open-liberty-operator.yaml -q -P ./base
     kubectl apply -k overlays/watch-all-namespaces
-    operatorDeploymentName=olo-controller-manager
 else
     # Install WebSphere Liberty Operator
+    operatorDeploymentName=websphere-liberty-controller-manager
     WLO_VERSION=1.0.2
     mkdir -p overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
@@ -186,7 +187,6 @@ else
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-deployment.yaml -q -P ./base
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-roles.yaml -q -P ./base
     kubectl apply -k overlays/watch-all-namespaces
-    operatorDeploymentName=websphere-liberty-controller-manager
 fi
 
 if [[ $? -ne 0 ]]; then
@@ -210,7 +210,7 @@ LOGIN_SERVER=$(az acr show -n $acrName --query 'loginServer' -o tsv)
 USER_NAME=$(az acr credential show -n $acrName --query 'username' -o tsv)
 PASSWORD=$(az acr credential show -n $acrName --query 'passwords[0].value' -o tsv)
 
-# Choose right template by checking if AGIC is enabled
+# Choose right template
 appDeploymentTemplate=open-liberty-application.yaml.template
 if [ "$ENABLE_APP_GW_INGRESS" = True ] && [ "$DEPLOY_WLO" = True ]; then
     appDeploymentTemplate=websphere-liberty-application-agic.yaml.template
@@ -220,7 +220,7 @@ elif [ "$ENABLE_APP_GW_INGRESS" = False ] && [ "$DEPLOY_WLO" = True ]; then
     appDeploymentTemplate=websphere-liberty-application.yaml.template
 fi
 
-appDeploymentFile=open-liberty-application.yaml
+appDeploymentFile=liberty-application.yaml
 export Enable_Cookie_Based_Affinity="${ENABLE_COOKIE_BASED_AFFINITY,,}"
 export App_Gw_Use_Private_Ip="${APP_GW_USE_PRIVATE_IP,,}"
 export Frontend_Tls_Secret=${APP_FRONTEND_TLS_SECRET_NAME}

--- a/src/main/scripts/websphere-liberty-application-agic.yaml.template
+++ b/src/main/scripts/websphere-liberty-application-agic.yaml.template
@@ -1,0 +1,76 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: ${Application_Name}
+  namespace: ${Project_Name}
+spec:
+  license:
+    accept: true
+    edition: ${WLA_Edition}
+    metric: ${WLA_Metric}
+    productEntitlementSource: ${WLA_Product_Entitlement_Source}
+  replicas: ${Application_Replicas}
+  applicationImage: ${Application_Image}
+  pullPolicy: Always
+  manageTLS: false
+  service:
+    type: ClusterIP
+    port: 9080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${Application_Name}-ingress-tls
+  namespace: ${Project_Name}
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
+    appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
+spec:
+  tls:
+  - secretName: ${Frontend_Tls_Secret}
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ${Application_Name}
+            port:
+              number: 9080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${Application_Name}-ingress
+  namespace: ${Project_Name}
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
+    appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ${Application_Name}
+            port:
+              number: 9080

--- a/src/main/scripts/websphere-liberty-application.yaml.template
+++ b/src/main/scripts/websphere-liberty-application.yaml.template
@@ -1,0 +1,32 @@
+#      Copyright (c) Microsoft Corporation.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
+metadata:
+  name: ${Application_Name}
+  namespace: ${Project_Name}
+spec:
+  license:
+    accept: true
+    edition: ${WLA_Edition}
+    metric: ${WLA_Metric}
+    productEntitlementSource: ${WLA_Product_Entitlement_Source}
+  replicas: ${Application_Replicas}
+  applicationImage: ${Application_Image}
+  pullPolicy: Always
+  manageTLS: false
+  service:
+    type: LoadBalancer
+    port: 9080


### PR DESCRIPTION
## Description

The PR is to simplify the user experience by resolving the following issues:
* Resolve #65

## Change summary

* Update UI to support install WebSphere Liberty Operator
* Update ARM templates to support WLO
* Update scripts to support WLO
* Add two more templates for support `WebSphereLibertyApplication` CR
* Update `integration-test` pipeline to support WLO

## Testing

Verified the following 8 test cases with `integration-test` pipeline (**Note**: For all cases enabled with **WLO**, **Edition** is `IBM WebSphere Application Server` and **Product entitlement source** is `Standalone`):
|AGIC |WLO|OLO|Sample App|Pipeline run|
|----- |------|-----|-------------|-------------|
|        |         |X     |                   |[integration-test-65](https://github.com/majguo/azure.liberty.aks/actions/runs/3341957166)|
|        |         |X     |X                 |[integration-test-66](https://github.com/majguo/azure.liberty.aks/actions/runs/3341960370)|
|X      |         |X     |                   |[integration-test-67](https://github.com/majguo/azure.liberty.aks/actions/runs/3341961520)|
|X      |         |X     |X                 |[integration-test-68](https://github.com/majguo/azure.liberty.aks/actions/runs/3341962468)|
|        |X       |       |                   |[integration-test-69](https://github.com/majguo/azure.liberty.aks/actions/runs/3342207085)|
|        |X       |       |X                 |[integration-test-70](https://github.com/majguo/azure.liberty.aks/actions/runs/3342209423)|
|X      |X       |       |                   |[integration-test-71](https://github.com/majguo/azure.liberty.aks/actions/runs/3342211302)|
|X      |X       |       |X                 |[integration-test-72](https://github.com/majguo/azure.liberty.aks/actions/runs/3342212611)|

Verified the following 5 test cases using [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks):
|AGIC |WLO|OLO|Sample App|Edition|Product entitlement source|
|----- |------|-----|-------------|--------|------------------------------|
|X      |         |X     |X                 |IBM WebSphere Application Server|Standalone|
|X      |X       |       |X                 |IBM WebSphere Application Server|Standalone|
|        |X       |       |X                 |IBM WebSphere Application Server Liberty Core|IBM WebSphere Hybrid Edition|
|        |X       |       |X                 |IBM WebSphere Application Server Network Deployment|IBM Cloud Pak for Applications|
|        |X       |       |X                 |IBM WebSphere Application Server Network Deployment|IBM WebSphere Application Server Family Edition|

Feel free to do a live testing with [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks).

## UI changes review

Besides visiting [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) for reviewing the renamed blade `Operator and application` (which comes from `Configure application`), reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.json](https://raw.githubusercontent.com/majguo/azure.liberty.aks/support-wlo/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- The UI changes in the renamed `Operator and application` blade include:
   - Add a new option **IBM supported? Yes/No**.
   - If selecting **Yes**, a checkbox **Accept license** and two more options **Edition** and **Product entitlement source** are displayed for user inputs. 

Also attached the screenshots for quick overview:

- **IBM supported: No (default)**
  ![image](https://user-images.githubusercontent.com/10357495/200326413-2f8ab18a-93d4-4231-9fb9-cf9c53c43d8c.png)

- **IBM supported: Yes**
  ![image](https://user-images.githubusercontent.com/10357495/200326586-795d1a9f-7102-4244-9d19-ff712f6550b6.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>