### PR TITLE
Refine ux and upgrade WLO to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.31</version>
+    <version>1.0.32</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -85,12 +85,12 @@
         "steps": [
             {
                 "name": "Cluster",
-                "label": "Configure cluster",
+                "label": "AKS",
                 "subLabel": {
                     "preValidation": "Provide required info for cluster configuration",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Configure cluster",
+                "bladeTitle": "AKS",
                 "elements": [
                     {
                         "name": "clusterInfo",
@@ -228,12 +228,12 @@
             },
             {
                 "name": "section_appGateway",
-                "label": "Networking",
+                "label": "Load balancing",
                 "subLabel": {
-                    "preValidation": "Provide required information for networking",
+                    "preValidation": "Provide required information for load balancing",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Networking",
+                "bladeTitle": "Load balancing",
                 "elements": [
                     {
                         "name": "appgwIngress",
@@ -245,7 +245,7 @@
                                 "type": "Microsoft.Common.TextBlock",
                                 "visible": true,
                                 "options": {
-                                    "text": "Select 'Yes' to configure an Application Gateway Ingress Controller",
+                                    "text": "Select 'Yes' to configure an Application Gateway Ingress Controller. If Application Gateway is not enabled, the user can simply use the standard load balancer that AKS comes with.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/azure-liberty-aks-app-gateway-ingress-controller"
@@ -654,24 +654,17 @@
                         "visible": "[bool(steps('Application').deployApplication)]"
                     },
                     {
-                        "name": "appLoadBalancingInfo",
-                        "type": "Microsoft.Common.Section",
-                        "label": "Load balancing",
-                        "elements": [
-                            {
-                                "name": "appReplicas",
-                                "type": "Microsoft.Common.Slider",
-                                "min": 1,
-                                "max": 20,
-                                "label": "Number of application replicas",
-                                "defaultValue": 2,
-                                "showStepMarkers": false,
-                                "toolTip": "The number of application replicas to deploy.",
-                                "constraints": {
-                                    "required": true
-                                }
-                            }
-                        ],
+                        "name": "appReplicas",
+                        "type": "Microsoft.Common.Slider",
+                        "min": 1,
+                        "max": 20,
+                        "label": "Number of application replicas",
+                        "defaultValue": 2,
+                        "showStepMarkers": false,
+                        "toolTip": "The number of application replicas to deploy.",
+                        "constraints": {
+                            "required": true
+                        },
                         "visible": "[bool(steps('Application').deployApplication)]"
                     }
                 ]
@@ -706,7 +699,7 @@
             "productEntitlementSource": "[steps('Application').productEntitlementSource]",
             "deployApplication": "[bool(steps('Application').deployApplication)]",
             "appImagePath": "[if(equals(steps('Application').appImageInfo.appImageOption, '2'), 'icr.io/appcafe/open-liberty/samples/getting-started', if(equals(steps('Application').appImageInfo.appImageOption, '3'), 'docker.io/ibmcom/websphere-liberty-sample:1.0.0', steps('Application').appImageInfo.appImagePath))]",
-            "appReplicas": "[int(steps('Application').appLoadBalancingInfo.appReplicas)]"
+            "appReplicas": "[int(steps('Application').appReplicas)]"
         }
     }
 }

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -176,7 +176,7 @@ if [ "$DEPLOY_WLO" = False ]; then
 else
     # Install WebSphere Liberty Operator
     operatorDeploymentName=websphere-liberty-controller-manager
-    WLO_VERSION=1.0.2
+    WLO_VERSION=1.1.0
     mkdir -p overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml -q -P ./overlays/watch-all-namespaces


### PR DESCRIPTION
The PR is to resolve Reza's end-to-end UX review comments:

> I did a quick end-to-end review of the Liberty on AKS offer. Everything looks great! I do think we should do a few minor improvements. Please rename the "Networking" tab to "Load balancing". We should explain somewhere in that tab that if App Gateway is not enabled, the user can simply use the standard load balancer that AKS comes with. We should also rename the "Configure cluster" tab to simply "AKS". Lastly, we should remove the "Load balancing" label that actually refers to replicas in the Applications tab.

Secondly, the PR also includes a commit to resolve the following issues by upgrading WLO to 1.1.0:
* Resolve #70 

The changes are tested and verified using the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>