### PR TITLE
Separate into multiple lines to work around line break issue

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -278,7 +278,7 @@
                                 "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
+                                    "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual<br>network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum<br>subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
                                 }
                             },
                             {
@@ -534,7 +534,7 @@
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
                             "icon": "Info",
-                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program. You must accept the license for the installation to work."
+                            "text": "I accept the terms on the license agreement corresponding to the version of IBM Program in the application container<br>by setting this value to true. See <a href='https://ibm.biz/was-license' target='_blank'>https://ibm.biz/was-license</a> for the license agreement applicable to this IBM Program.<br>You must accept the license for the installation to work."
                         },
                         "visible": "[and(bool(steps('Application').deployWLO), bool(steps('Application').deployApplication))]"
                     },
@@ -633,7 +633,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'. For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty', and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
+                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
                                 },
                                 "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             },


### PR DESCRIPTION
Work around `Declarative Info box cuts off the message` issue by manually separating long line into multiple lines.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>