### PR TITLE
Upgrade wlo to 1.2.0

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -159,7 +159,7 @@ jobs:
         with:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
-            az group delete -n ${{ env.testResourceGroup }} --yes
+            az group delete -n ${{ env.testResourceGroup }} --yes --no-wait
       - name: Generate artifact file name and path
         id: artifact_file
         run: |

--- a/docs/update-olo-wlo-version.md
+++ b/docs/update-olo-wlo-version.md
@@ -1,0 +1,19 @@
+## How to update the version of Open Liberty Operator and WebSphere Liberty Operator
+
+Follow instructions below to update the version of Open Liberty Operator:
+
+1. Open https://github.com/WASdev/azure.liberty.aks/blob/main/src/main/scripts/install.sh
+1. Search `OLO_VERSION=`
+1. Update its value with new version. For example, if you want to update to version `0.8.2`, specify it as `OLO_VERSION=0.8.2`
+
+Follow instructions below to update the version of WebSphere Liberty Operator:
+
+1. Open https://github.com/WASdev/azure.liberty.aks/blob/main/src/main/scripts/install.sh
+1. Search `WLO_VERSION=`
+1. Update its value with new version. For example, if you want to update to version `1.1.0`, specify it as `WLO_VERSION=1.1.0`
+
+At the end, bump verion in https://github.com/WASdev/azure.liberty.aks/blob/main/pom.xml#L23:
+
+```
+<version>THE_NEW_VERSION</version>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.33</version>
+    <version>1.0.34</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -176,7 +176,7 @@ if [ "$DEPLOY_WLO" = False ]; then
 else
     # Install WebSphere Liberty Operator
     operatorDeploymentName=websphere-liberty-controller-manager
-    WLO_VERSION=1.1.0
+    WLO_VERSION=1.2.0
     mkdir -p overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/wlo-all-namespaces.yaml -q -P ./overlays/watch-all-namespaces
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/overlays/watch-all-namespaces/cluster-roles.yaml -q -P ./overlays/watch-all-namespaces


### PR DESCRIPTION
The PR is to resolve #81, along with a simple guide on how to update the version of Open Liberty Operator / WebSphere Liberty Operator. Code changes are verified with [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/4815604706).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>