### PR TITLE
Fix deployment failure

### DIFF
--- a/src/main/scripts/open-liberty-application-agic.yaml.template
+++ b/src/main/scripts/open-liberty-application-agic.yaml.template
@@ -32,10 +32,10 @@ metadata:
   name: ${Application_Name}-ingress-tls
   namespace: ${Project_Name}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
     appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
 spec:
+  ingressClassName: azure-application-gateway
   tls:
   - secretName: ${Frontend_Tls_Secret}
   rules:
@@ -55,10 +55,10 @@ metadata:
   name: ${Application_Name}-ingress
   namespace: ${Project_Name}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
     appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
 spec:
+  ingressClassName: azure-application-gateway
   rules:
   - http:
       paths:

--- a/src/main/scripts/websphere-liberty-application-agic.yaml.template
+++ b/src/main/scripts/websphere-liberty-application-agic.yaml.template
@@ -38,10 +38,10 @@ metadata:
   name: ${Application_Name}-ingress-tls
   namespace: ${Project_Name}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
     appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
 spec:
+  ingressClassName: azure-application-gateway
   tls:
   - secretName: ${Frontend_Tls_Secret}
   rules:
@@ -61,10 +61,10 @@ metadata:
   name: ${Application_Name}-ingress
   namespace: ${Project_Name}
   annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/cookie-based-affinity: "${Enable_Cookie_Based_Affinity}"
     appgw.ingress.kubernetes.io/use-private-ip: "${App_Gw_Use_Private_Ip}"
 spec:
+  ingressClassName: azure-application-gateway
   rules:
   - http:
       paths:


### PR DESCRIPTION
The PR is to fix #93 (liberty on aks offer deployment failure) which was caused by the issue that the agic pod is not immediately running after installation. The fix is to retry and wait until the agic pod is running.

It also fixed a warning *Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead* by using 'spec.ingressClassName'.

## Test

The deployment succeeded with the fix, see:
* [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/7483546947)
* [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/7483009616)
* [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/7482504615)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>