### PR TITLE
Fix deployment failure (acr not found)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.38</version>
+    <version>1.0.39</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -489,6 +489,7 @@ module primaryDsDeployment 'modules/_deployment-scripts/_ds-primary.bicep' = {
     _artifactsLocationSasToken: _artifactsLocationSasToken
     identity: obj_uamiForDeploymentScript
     arguments: const_arguments
+    acrRGName: const_acrRGName
     deployWLO: deployWLO
     edition: edition
     productEntitlementSource: productEntitlementSource

--- a/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-primary.bicep
@@ -22,6 +22,7 @@ param location string
 param name string = ''
 param identity object = {}
 param arguments string = ''
+param acrRGName string = ''
 param deployWLO bool = false
 param edition string = 'IBM WebSphere Application Server'
 param productEntitlementSource string = 'Standalone'
@@ -44,6 +45,10 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   properties: {
     azCliVersion: '2.15.0'
     environmentVariables: [
+      {
+        name: 'ACR_RG_NAME'
+        value: string(acrRGName)
+      }
       {
         name: 'ENABLE_APP_GW_INGRESS'
         value: string(enableAppGWIngress)

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -236,9 +236,9 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Retrieve login server and credentials of the ACR
-LOGIN_SERVER=$(az acr show -n $acrName --query 'loginServer' -o tsv)
-USER_NAME=$(az acr credential show -n $acrName --query 'username' -o tsv)
-PASSWORD=$(az acr credential show -n $acrName --query 'passwords[0].value' -o tsv)
+LOGIN_SERVER=$(az acr show -n $acrName -g $ACR_RG_NAME --query 'loginServer' -o tsv)
+USER_NAME=$(az acr credential show -n $acrName -g $ACR_RG_NAME --query 'username' -o tsv)
+PASSWORD=$(az acr credential show -n $acrName -g $ACR_RG_NAME --query 'passwords[0].value' -o tsv)
 
 # Choose right template
 appDeploymentTemplate=open-liberty-application.yaml.template
@@ -262,7 +262,7 @@ export WLA_Metric="${WLA_METRIC}"
 if [ "$deployApplication" = True ]; then
     # Log into the ACR and import application image
     docker login $LOGIN_SERVER -u $USER_NAME -p $PASSWORD >> $logFile 2>/dev/null
-    az acr import -n $acrName --source ${sourceImagePath} -t ${Application_Image} >> $logFile
+    az acr import -n $acrName -g $ACR_RG_NAME --source ${sourceImagePath} -t ${Application_Image} >> $logFile
     if [[ $? != 0 ]]; then
         echo "Unable to import source image ${sourceImagePath} to the Azure Container Registry instance. Please check if it's a public image and the source image path is correct" >&2
         exit 1


### PR DESCRIPTION
The PR is to fix #97 ([liberty on aks offer deployment failure due to acr not found](https://github.com/majguo/azure.liberty.aks/actions/runs/7794521425)) which was caused by the issue that the acr can't be retrieved without specifying resource group. The fix is to specify resource group name for the acr when retrieving its information.

## Test

The deployment succeeded with the fix, see:
* [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/7794848723)
* [integration-test](https://github.com/majguo/azure.liberty.aks/actions/runs/7794925024)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>