### PR TITLE
Remove azure javaee in workflows

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -58,39 +58,31 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d ../arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - name: Build ${{ env.repoName }}
         run: |
           enableAppGWIngress=false

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -66,7 +66,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -75,27 +74,23 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Checkout arm-ttk
         uses: actions/checkout@v2
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
           ref: ${{ env.refArmttk }}
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Build ${{ env.repoName }}
         run: |
           enableAppGWIngress=false

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d ../arm-ttk
+          unzip arm-template-toolkit.zip -d arm-ttk
 
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -80,11 +80,10 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
+      - name: Download arm-ttk used in partner center pipeline
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -85,7 +85,6 @@ jobs:
         with:
           repository: Azure/arm-ttk
           path: arm-ttk
-          ref: ${{ env.refArmttk }}
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -83,11 +83,12 @@ jobs:
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
 
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
 
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -80,10 +80,11 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Download arm-ttk used in partner center pipeline
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -63,6 +63,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
 
       - name: Set up bicep
         run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -47,26 +46,22 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Download arm-ttk used in partner center pipeline
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}
@@ -81,7 +76,6 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
-
       - name: Archive ${{ env.repoName }} template
         uses: actions/upload-artifact@v1
         if: success()

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) IBM Corporation.
 # Copyright (c) Microsoft Corporation.
-name: Package ARM
+name: Package ARM and Update Offer Artifact
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml --non-recursive exec:exec)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file pom.xml --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -81,9 +81,7 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+
       - name: Archive ${{ env.repoName }} template
         uses: actions/upload-artifact@v1
         if: success()

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -8,7 +8,7 @@ on:
         description: 'Update offer artifact'
         required: true
         type: boolean
-        default: false
+        default: true
 
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -36,8 +36,8 @@ jobs:
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-            server-username: MAVEN_USERNAME # env variable for username
-            server-password: MAVEN_TOKEN # env variable for token
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
 
       - name: Set Maven env
         env:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -74,7 +74,8 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file pom.xml --non-recursive exec:exec)
+          echo "pwd=$(pwd)"
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml  --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -82,6 +82,7 @@ jobs:
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
       - name: Setup tmate session
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
       - name: Archive ${{ env.repoName }} template
         uses: actions/upload-artifact@v1

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -81,6 +81,8 @@ jobs:
           echo "##[set-output name=artifactName;]${artifactName}"
           echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
           echo "##[set-output name=artifactVersion;]${version}"
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Archive ${{ env.repoName }} template
         uses: actions/upload-artifact@v1
         if: success()

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -30,37 +30,43 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+            server-username: MAVEN_USERNAME # env variable for username
+            server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
+
       - name: Download arm-ttk used in partner center pipeline
+        shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}
@@ -68,7 +74,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.repoName }}}' --file ${{ env.repoName }}/pom.xml --non-recursive exec:exec)
           artifactName=${{ env.repoName }}-$version-arm-assembly
           unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -3,6 +3,13 @@
 name: Package ARM
 on:
   workflow_dispatch:
+    inputs:
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: false
+
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.liberty.aks
@@ -83,6 +90,7 @@ jobs:
           name: ${{steps.artifact_file.outputs.artifactName}}
           path: ${{steps.artifact_file.outputs.artifactPath}}
       - name: Update offer artifact
+        if: ${{ inputs.updateOfferArtifact == true || github.event.client_payload.updateOfferArtifact == true }}
         uses: microsoft/microsoft-partner-center-github-action@v3
         with:
           offerId: ${{ env.offerId }}

--- a/README.md
+++ b/README.md
@@ -36,10 +36,18 @@ Please follow these steps:
     - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-    - Locate or create the settings.xml file in your .m2 directory.
+    - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
     - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
        ```xml
-        <settings>
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                               https://maven.apache.org/xsd/settings-1.2.0.xsd">
+         
+       <!-- other settings
+       ...
+       -->
+      
          <servers>
            <server>
              <id>github</id>
@@ -47,6 +55,11 @@ Please follow these steps:
              <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
            </server>
          </servers>
+      
+       <!-- other settings
+       ...
+       -->
+      
         </settings>
        ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,34 @@
 1. Install [Bicep](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install#linux).
 1. Install [`jq`](https://stedolan.github.io/jq/download/)
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+    - Go to [Personal access tokens](https://github.com/settings/tokens).
+    - Click on Generate new token.
+    - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+    - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+    - Locate or create the settings.xml file in your .m2 directory.
+    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+       ```xml
+        <settings>
+         <servers>
+           <server>
+             <id>github</id>
+             <username>YOUR_GITHUB_USERNAME</username>
+             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+           </server>
+         </servers>
+        </settings>
+       ```
+
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/docs/howto-update-offer-in-partner-center.md
+++ b/docs/howto-update-offer-in-partner-center.md
@@ -37,7 +37,7 @@ If you make any changes for files located in the following path:
 
 If you haven't incremented the version, pls do so before publishing the solution template to partner center. 
 
-1. Increase the [version number](https://github.com/WASdev/azure.liberty.aks/blob/main/pom.xml#L23) which is specified in the `pom.xml`.
+1. Increase the [version number](https://github.com/WASdev/azure.liberty.aks/blob/main/pom.xml#L31) which is specified in the `version.azure.liberty.aks` property in `pom.xml`.
 1. If creating a new Plan, update the `pid` value as described in [How Azure customer usage attribution works in the IBM Partner Center offers](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/docs/howto-update-pids.md).
 1. Get the PR merged.
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,13 @@
     <version>1.0.43</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
-    
+
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
-        <relativePath></relativePath>
+        <version>1.0.20</version>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
@@ -39,4 +38,21 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.20</version>
+        <version>1.0.22</version>
         <relativePath></relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,17 +19,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.microsoft.azure.iaas</groupId>
+        <artifactId>azure-javaee-iaas-parent</artifactId>
+        <version>1.0.20</version>
+        <relativePath></relativePath>
+    </parent>
+
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
     <version>1.0.43</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
-
-    <parent>
-        <groupId>com.microsoft.azure.iaas</groupId>
-        <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.20</version>
-    </parent>
 
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.liberty.aks</artifactId>
-    <version>1.0.43</version>
+    <version>${version.azure.liberty.aks}</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
 
@@ -38,6 +38,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
+        <version.azure.liberty.aks>1.0.41</version.azure.liberty.aks>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.liberty.aks>1.0.41</version.azure.liberty.aks>
+        <version.azure.liberty.aks>1.0.42</version.azure.liberty.aks>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows and Maven configuration to simplify the build process and improve the integration with GitHub Packages. The most important changes include removing unnecessary environment variables, adding Maven environment setup, updating the way version is fetched, and adding GitHub Packages as a repository in the Maven configuration.

Changes to GitHub workflows:

* [`.github/workflows/integration-test.yaml`](diffhunk://#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0L61-L80): Removed unnecessary environment variables like `azCliVersion`, `refArmttk`, and `refJavaee`. Added Maven environment setup and updated the way version is fetched. Removed the checkout and build steps for `azure-javaee-iaas`. 
* [`.github/workflows/package.yaml`](diffhunk://#diff-154ccb2e01a195c7f4431e94b51c9f2e69bcbda5891ebfbc53b99719cd46e4e2L3-R12): Similar changes as in `integration-test.yaml`. In addition, updated the offer artifact update condition to check for `inputs.updateOfferArtifact` or `github.event.client_payload.updateOfferArtifact`. 
Changes to Maven configuration:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L22-R59): Moved the `groupId`, `artifactId`, and `version` tags below the `parent` tag. Updated the parent version to `1.0.22`. Added a new property `version.azure.liberty.aks` and set its value to `1.0.42`. Added GitHub Packages as a repository and a plugin repository.

Documentation changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R52): Added a new section "Local Build Setup and Requirements" to guide users on how to configure Maven for GitHub Packages.