### PR TITLE
BugFix: Offers can' be redeployed with the same resource group as before with different region in the same subscription

### DIFF
--- a/src/main/bicep/modules/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uamiAndRoles.bicep
@@ -16,11 +16,12 @@
 */
 
 param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity'
-var name_deploymentScriptContributorRoleAssignmentName = guid('${resourceGroup().id}${name_deploymentScriptUserDefinedManagedIdentity}Deployment Script')
+var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
+
 
 // UAMI for deployment script
 resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {

--- a/src/main/bicep/modules/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uamiAndRoles.bicep
@@ -20,7 +20,7 @@ param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
 
 // https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
 var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
+var name_deploymentScriptUserDefinedManagedIdentity = 'ol-aks-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
 
 
 // UAMI for deployment script


### PR DESCRIPTION
## Context
If I try to do following steps, it will fail.
Step 1. Deploy current offer in resource group rg-a and region east us
Step 2. Delete resource group rg-a
Step 3. Deploy current offer in resource group rg-a and region west us

And this PR is used to fix this bug.


## Tests
- [Package ARM and Update Offer Artifact #28](https://github.com/azure-javaee/azure.liberty.aks/actions/runs/9065162459)
- [integration-test #35](https://github.com/azure-javaee/azure.liberty.aks/actions/runs/9065159999)
<img width="1106" alt="image" src="https://github.com/WASdev/azure.liberty.aks/assets/4465723/22eff990-282f-48c6-9895-7aa86ff274d1">
