### PR TITLE
Fix integration-test failure

### DIFF
--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -216,7 +216,7 @@ else
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-deployment.yaml -q -P ./base
     wget https://raw.githubusercontent.com/WASdev/websphere-liberty-operator/main/deploy/releases/${WLO_VERSION}/kustomize/base/websphere-liberty-roles.yaml -q -P ./base
     kubectl create namespace ${operatorNamespaceName}
-    kubectl apply -k overlays/watch-all-namespaces
+    kubectl apply --server-side -k overlays/watch-all-namespaces
 fi
 
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This is a follow-up PR for #111, which fixes integration test failure captured in [integration-test](https://github.com/WASdev/azure.liberty.aks/actions/runs/9556495381).
The fix refences the official WLO installation guide from https://www.ibm.com/docs/en/was-liberty/base?topic=cli-installing-kustomize.

## Testing

The pipelines with the fix ran successfully:
* WLO: [integration-test-142](https://github.com/majguo/azure.liberty.aks/actions/runs/9637849303)
* OLO: [integration-test-143](https://github.com/majguo/azure.liberty.aks/actions/runs/9638150151)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>