### PR TITLE
On branch edburns-msft-ibm-7891-support-pre-pushed-acr-image WIP: support deployment of pre-pushed image to pre-existing Azure Container Registry, such as ejb02ibm781.azurecr.io/jakartaee-microprofile-example:v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.liberty.aks>1.0.48</version.azure.liberty.aks>
+        <version.azure.liberty.aks>1.0.49</version.azure.liberty.aks>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.liberty.aks>1.0.35</version.azure.liberty.aks>
+        <version.azure.liberty.aks>1.0.48</version.azure.liberty.aks>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
-        <version.azure.liberty.aks>1.0.48</version.azure.liberty.aks>
+        <version.azure.liberty.aks>1.0.35</version.azure.liberty.aks>
     </properties>
 
     <repositories>

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -171,8 +171,9 @@ var const_appGatewaySSLCertOptionHaveKeyVault = 'haveKeyVault'
 var const_appFrontendTlsSecretName = format('secret{0}', guidValue)
 var const_appImage = format('{0}:{1}', const_appImageName, const_appImageTag)
 var const_appImageName = format('image{0}', guidValue)
-var const_appImagePath = (empty(appImagePath) ? 'NA' : ((const_appImagePathLen == 1) ? format('docker.io/library/{0}', appImagePath) : ((const_appImagePathLen == 2) ? format('docker.io/{0}', appImagePath) : appImagePath)))
 var const_appImagePathLen = length(split(appImagePath, '/'))
+var const_appImagePathLoginServer = split(appImagePath, '/')[0]
+var const_appImagePath = (empty(appImagePath) ? 'NA' : ((const_appImagePathLen == 1) ? format('docker.io/library/{0}', appImagePath) : ((const_appImagePathLen == 2) ? (endsWith(const_appImagePathLoginServer, 'azurecr.io') ? appImagePath : format('docker.io/{0}', appImagePath)) : appImagePath)))
 var const_appImageTag = '1.0.0'
 var const_appName = format('app{0}', guidValue)
 var const_appProjName = 'default'

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -247,6 +247,8 @@ module preflightDsDeployment 'modules/_deployment-scripts/_ds-preflight.bicep' =
     vmSize: vmSize
     deployApplication: deployApplication
     sourceImagePath: const_appImagePath
+    createACR: createACR
+    acrName: name_acrName
     acrRGName: const_acrRGName
   }
   dependsOn: [

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -247,6 +247,7 @@ module preflightDsDeployment 'modules/_deployment-scripts/_ds-preflight.bicep' =
     vmSize: vmSize
     deployApplication: deployApplication
     sourceImagePath: const_appImagePath
+    acrRGName: const_acrRGName
   }
   dependsOn: [
     uamiDeployment

--- a/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
@@ -38,6 +38,8 @@ param appGatewaySSLCertPassword string = ''
 param vmSize string
 param deployApplication bool
 param sourceImagePath string
+param createACR bool = true
+param acrName string = ''
 param acrRGName string = ''
 
 param utcValue string = utcNow()
@@ -63,7 +65,7 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVers
       {
         name: 'AKS_CLUSTER_RG_NAME'
         value: aksClusterRGName
-      }      
+      }
       {
         name: 'ENABLE_APPLICATION_GATEWAY_INGRESS_CONTROLLER'
         value: string(enableAppGWIngress)
@@ -117,8 +119,16 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVers
         value: sourceImagePath
       }
       {
+        name: 'CREATE_ACR'
+        value: string(createACR)
+      }
+      {
+        name: 'ACR_NAME'
+        value: acrName
+      }
+      {
         name: 'ACR_RG_NAME'
-        value: string(acrRGName)
+        value: acrRGName
       }
     ]
     primaryScriptUri: uri(const_scriptLocation, 'preflight.sh${_artifactsLocationSasToken}')

--- a/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_ds-preflight.bicep
@@ -38,6 +38,7 @@ param appGatewaySSLCertPassword string = ''
 param vmSize string
 param deployApplication bool
 param sourceImagePath string
+param acrRGName string = ''
 
 param utcValue string = utcNow()
 
@@ -114,6 +115,10 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVers
       {
         name: 'SOURCE_IMAGE_PATH'
         value: sourceImagePath
+      }
+      {
+        name: 'ACR_RG_NAME'
+        value: string(acrRGName)
       }
     ]
     primaryScriptUri: uri(const_scriptLocation, 'preflight.sh${_artifactsLocationSasToken}')

--- a/src/main/scripts/preflight.sh
+++ b/src/main/scripts/preflight.sh
@@ -187,8 +187,16 @@ if [[ "${DEPLOY_APPLICATION,,}" == "true" ]]; then
     if echo "$arches" | grep -q '^amd64$'; then
       echo_stdout "Image $SOURCE_IMAGE_PATH supports amd64 architecture." $(cat inspect_output.txt)
     else
-      echo_stderr "Image $SOURCE_IMAGE_PATH does not support amd64 architecture." $(cat inspect_output.txt)
-      exit 1
+      echo_stdout "No amd64 architecture found from the manifest of image $SOURCE_IMAGE_PATH." $(cat inspect_output.txt)
+      # Retry by inspecting the manifest with --verbose option
+      docker manifest inspect $SOURCE_IMAGE_PATH --verbose > inspect_verbose_output.txt 2>&1
+      arches=$(cat inspect_verbose_output.txt | jq -r '.Descriptor.platform.architecture')
+      if echo "$arches" | grep -q '^amd64$'; then
+        echo_stdout "Image $SOURCE_IMAGE_PATH supports amd64 architecture." $(cat inspect_verbose_output.txt)
+      else
+        echo_stderr "Image $SOURCE_IMAGE_PATH does not support amd64 architecture." $(cat inspect_verbose_output.txt)
+        exit 1
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
On branch edburns-msft-ibm-7891-support-pre-pushed-acr-image Skip inspecting the manifest if the image comes from Azure Container Registry.
modified:   pom.xml

- Increment version.

modified:   src/main/scripts/preflight.sh

- Assume that if SOURCE_IMAGE_PATH comes from azurecr.io it is assumed to meet the requirements of being a valid container image for running Liberty on Kubernetes.

modified:   src/main/bicep/mainTemplate.bicep

- Fix issue where fully qualified azurecr.io tags were incorrectly prepended with docker.io.