### PR TITLE
Allow pre-built image stored in the specified acr

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -727,7 +727,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "The image you provide must satisfy one of the following conditions:<br> <li>A public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'.</li><li>A pre-built image stored in the Azure Container Registry you specified in the <b>AKS</b> tab.</li>"
+                                    "text": "The image you provide must satisfy one of the following conditions:<br> <li>A public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'.</li><li>A pre-built image stored in the Azure Container Registry you specified in the <b>AKS</b> tab.<br>For example, 'contoso.azurecr.io/myapp:v1'"
                                 },
                                 "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             },

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -727,7 +727,7 @@
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "Please provide a public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'."
+                                    "text": "The image you provide must satisfy one of the following conditions:<br> <li>A public image which is accessible without credentials. If you input a fully qualified container image path<br>containing the registry login server, it's used directly. Otherwise, the login server is assumed to be 'docker.io'.<br>For example, 'websphere-liberty' will be converted to 'docker.io/library/websphere-liberty',<br>and 'ibmcom/websphere-liberty' will be converted to 'docker.io/ibmcom/websphere-liberty'.</li><li>A pre-built image stored in the Azure Container Registry you specified in the <b>AKS</b> tab.</li>"
                                 },
                                 "visible": "[equals(steps('Application').appImageInfo.appImageOption, '1')]"
                             },


### PR DESCRIPTION
This PR is a follow-up of #117, by refining works to let user know that the pre-built image stored in the specified acr is allowed in the deployment of `liberty-on-aks` offer.

## Testing

Before:
![image](https://github.com/user-attachments/assets/f75f22a1-5172-4f1c-857b-4857a7a5000a)

After:
![image](https://github.com/user-attachments/assets/8eab1e9a-61b1-4341-ae75-5637a9821fb7)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>